### PR TITLE
feat: add implementation-review skill for cross-task review

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -42,9 +42,16 @@ Based on feedback:
 - Execute next batch
 - Repeat until complete
 
-### Step 5: Complete Development
+### Step 5: Implementation Review
 
 After all tasks complete and verified:
+- **REQUIRED SUB-SKILL:** Use superpowers:implementation-review
+- Fresh-eyes review of entire feature (base-branch..HEAD, not just final batch)
+- Fix any cross-task issues found, re-run until clean
+
+### Step 6: Complete Development
+
+After implementation review passes:
 - Announce: "I'm using the finishing-a-development-branch skill to complete this work."
 - **REQUIRED SUB-SKILL:** Use superpowers:finishing-a-development-branch
 - Follow that skill to verify tests, present options, execute choice
@@ -81,4 +88,5 @@ After all tasks complete and verified:
 **Required workflow skills:**
 - **superpowers:using-git-worktrees** - REQUIRED: Set up isolated workspace before starting
 - **superpowers:writing-plans** - Creates the plan this skill executes
+- **superpowers:implementation-review** - Fresh-eyes review of entire feature after all batches
 - **superpowers:finishing-a-development-branch** - Complete development after all tasks

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -193,8 +193,8 @@ git worktree remove <worktree-path>
 ## Integration
 
 **Called by:**
-- **subagent-driven-development** (Step 7) - After all tasks complete
-- **executing-plans** (Step 5) - After all batches complete
+- **subagent-driven-development** - After implementation-review passes
+- **executing-plans** (Step 6) - After implementation-review passes
 
 **Pairs with:**
 - **using-git-worktrees** - Cleans up worktree created by that skill

--- a/skills/implementation-review/SKILL.md
+++ b/skills/implementation-review/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: implementation-review
+description: Use when a multi-task implementation is complete and ready for holistic review before merging — catches cross-task inconsistencies, duplication, and dead code that per-task reviews miss
+---
+
+# Implementation Review
+
+Review the entire feature implementation with fresh eyes, focusing on issues that only surface when looking at all tasks together.
+
+**Core principle:** Per-task reviews verify each piece works. Implementation review verifies the pieces work together.
+
+## When to Use
+
+- After all tasks complete in subagent-driven-development (auto-suggested)
+- After executing-plans completes all batches
+- Before merging any multi-task feature branch
+- When asked to "review the whole thing" or "look at everything with fresh eyes"
+
+**Not needed for:** Single-task changes, hotfixes, documentation-only PRs.
+
+## The Process
+
+```dot
+digraph process {
+    rankdir=TB;
+    "Get base branch SHA (origin/main or where feature diverged)" [shape=box];
+    "Get HEAD SHA (current commit)" [shape=box];
+    "Dispatch reviewer subagent with ./reviewer-prompt.md" [shape=box];
+    "Reviewer finds issues?" [shape=diamond];
+    "Fix issues (dispatch implementer or fix directly)" [shape=box];
+    "Re-run implementation review" [shape=box];
+    "Proceed to superpowers:finishing-a-development-branch" [shape=box style=filled fillcolor=lightgreen];
+
+    "Get base branch SHA (origin/main or where feature diverged)" -> "Get HEAD SHA (current commit)";
+    "Get HEAD SHA (current commit)" -> "Dispatch reviewer subagent with ./reviewer-prompt.md";
+    "Dispatch reviewer subagent with ./reviewer-prompt.md" -> "Reviewer finds issues?";
+    "Reviewer finds issues?" -> "Fix issues (dispatch implementer or fix directly)" [label="yes"];
+    "Fix issues (dispatch implementer or fix directly)" -> "Re-run implementation review" [label="re-review"];
+    "Re-run implementation review" -> "Reviewer finds issues?";
+    "Reviewer finds issues?" -> "Proceed to superpowers:finishing-a-development-branch" [label="no"];
+}
+```
+
+## How to Dispatch
+
+```bash
+# Get the FULL feature range — not just the last task
+BASE_SHA=$(git merge-base HEAD origin/main)  # or origin/master
+HEAD_SHA=$(git rev-parse HEAD)
+```
+
+Then dispatch using `./reviewer-prompt.md` template with:
+- `{BASE_SHA}` — where the feature branch diverged
+- `{HEAD_SHA}` — current tip
+- `{FEATURE_SUMMARY}` — what the feature does (1-2 sentences)
+- `{TASK_LIST}` — list of tasks that were implemented
+
+**Critical:** The diff range must cover ALL tasks, not just the last one. This is the entire point of the skill.
+
+## What It Catches (That Per-Task Reviews Miss)
+
+| Category | Example | Why Per-Task Misses It |
+|----------|---------|----------------------|
+| Cross-task inconsistency | Config says port 3000, README says 8080 | Each file reviewed in isolation |
+| Duplicated constants | Same timeout defined in two modules | Each task added it independently |
+| Code duplication | Identical function in two files, different names | Each task's reviewer only sees one copy |
+| Dead code from iteration | Conditional where both branches are identical | Emerged from incremental changes across tasks |
+| Documentation gaps | Feature supported in one module but not another, undocumented | Per-task reviewer sees one side |
+| Unclear/inconsistent errors | Multiple modules throw same generic message | Each reviewer sees one throw site |
+
+## Red Flags
+
+**Never:**
+- Use per-task SHA range (defeats the purpose)
+- Skip this because per-task reviews passed (that's exactly when cross-task issues hide)
+- Treat this as optional for multi-task features
+
+**If reviewer finds issues:**
+- Fix them before proceeding to finishing-a-development-branch
+- Re-run the review after fixes
+- Don't skip re-review
+
+## Integration
+
+**Called by:**
+- **superpowers:subagent-driven-development** — auto-suggested after all tasks complete
+- **superpowers:executing-plans** — after all batches complete
+
+**Leads to:**
+- **superpowers:finishing-a-development-branch** — once review passes

--- a/skills/implementation-review/reviewer-prompt.md
+++ b/skills/implementation-review/reviewer-prompt.md
@@ -1,0 +1,107 @@
+# Implementation Review Prompt Template
+
+Use this template when dispatching a fresh-eyes reviewer subagent for the entire feature.
+
+**Purpose:** Catch cross-task issues that per-task reviews miss — inconsistencies, duplication, dead code, documentation gaps.
+
+**Only dispatch after all tasks are complete and their individual reviews have passed.**
+
+```
+Task tool (general-purpose):
+  model: "opus"
+  description: "Fresh-eyes implementation review"
+  prompt: |
+    You are performing a fresh-eyes review of an entire feature implementation.
+    Per-task spec and code quality reviews have already passed. Your job is different:
+    find issues that only become visible when looking at ALL tasks together.
+
+    ## Feature Summary
+
+    {FEATURE_SUMMARY}
+
+    ## Tasks Implemented
+
+    {TASK_LIST}
+
+    ## Git Range
+
+    The code is at {REPO_PATH}
+
+    ```bash
+    git diff --stat {BASE_SHA}..{HEAD_SHA}
+    git diff {BASE_SHA}..{HEAD_SHA}
+    ```
+
+    Review ALL files in the diff. Read every file that was changed.
+
+    ## Your Focus: Cross-Task Issues
+
+    Per-task reviewers already checked code quality, test coverage, and spec compliance
+    for each task individually. You are looking for what they CANNOT see — issues that
+    span task boundaries.
+
+    **Actively hunt for these categories:**
+
+    1. **Cross-task inconsistencies**
+       - Values that should match but don't (ports, URLs, defaults, config keys)
+       - Naming conventions that drift between tasks
+       - Behavior assumptions that contradict across modules
+
+    2. **Duplicated code or constants**
+       - Same logic implemented in multiple files under different names
+       - Same magic number or constant defined independently
+       - Shared utilities that should be extracted
+
+    3. **Dead code from incremental development**
+       - Conditionals where both branches do the same thing
+       - Functions that were added early but never called
+       - Code paths made unreachable by later tasks
+
+    4. **Documentation gaps**
+       - Features supported in one module but not wired up in another
+       - README/docs that contradict actual behavior
+       - Missing explanation of intentional limitations
+
+    5. **Inconsistent error handling**
+       - Same generic error message from multiple locations
+       - Error messages that don't explain what the user did wrong
+       - Missing error context (status codes, input values, expected formats)
+
+    6. **Integration gaps**
+       - Config flags defined but never checked
+       - Return values computed but never used by callers
+       - Interfaces defined in one task but not implemented where needed
+
+    ## How to Review
+
+    1. Read the full diff to understand the feature as a whole
+    2. For each file, note what it exports and what other files consume
+    3. Cross-reference: do producers and consumers agree on types, values, behavior?
+    4. Look for patterns that repeat across files (duplication signal)
+    5. Check documentation against actual implementation
+
+    ## Output Format
+
+    ### Cross-Task Issues Found
+
+    For each issue:
+    - **Category** (from the 6 above)
+    - **Files involved** (with line references)
+    - **What's wrong**
+    - **Why per-task review missed it**
+    - **Suggested fix**
+
+    ### Assessment
+
+    **Issues found:** [count]
+    **Severity:** [Critical / Important / Minor for each]
+    **Ready to merge after fixing these?** [Yes/No]
+
+    ## Critical Rules
+
+    - DO NOT re-review per-task concerns (code style, individual test coverage)
+    - DO focus exclusively on cross-task and integration issues
+    - Be specific: file:line references, not vague suggestions
+    - If you find zero cross-task issues, say so — don't invent problems
+    - DO NOT modify any files. Read-only review.
+```

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -58,7 +58,7 @@ digraph process {
 
     "Read plan, extract all tasks with full text, note context, create TodoWrite" [shape=box];
     "More tasks remain?" [shape=diamond];
-    "Dispatch final code reviewer subagent for entire implementation" [shape=box];
+    "Use superpowers:implementation-review for fresh-eyes review of entire feature" [shape=box];
     "Use superpowers:finishing-a-development-branch" [shape=box style=filled fillcolor=lightgreen];
 
     "Read plan, extract all tasks with full text, note context, create TodoWrite" -> "Dispatch implementer subagent (./implementer-prompt.md)";
@@ -77,8 +77,8 @@ digraph process {
     "Code quality reviewer subagent approves?" -> "Mark task complete in TodoWrite" [label="yes"];
     "Mark task complete in TodoWrite" -> "More tasks remain?";
     "More tasks remain?" -> "Dispatch implementer subagent (./implementer-prompt.md)" [label="yes"];
-    "More tasks remain?" -> "Dispatch final code reviewer subagent for entire implementation" [label="no"];
-    "Dispatch final code reviewer subagent for entire implementation" -> "Use superpowers:finishing-a-development-branch";
+    "More tasks remain?" -> "Use superpowers:implementation-review for fresh-eyes review of entire feature" [label="no"];
+    "Use superpowers:implementation-review for fresh-eyes review of entire feature" -> "Use superpowers:finishing-a-development-branch";
 }
 ```
 
@@ -158,9 +158,15 @@ Code reviewer: ✅ Approved
 ...
 
 [After all tasks]
-[Dispatch final code-reviewer]
-Final reviewer: All requirements met, ready to merge
+[Use superpowers:implementation-review — fresh-eyes review of entire feature]
+Implementation reviewer: Found 2 cross-task issues:
+  - Duplicated constant in fetcher.ts and cache.ts
+  - Error message in cli.ts doesn't explain what went wrong
 
+[Fix cross-task issues, re-run implementation review]
+Implementation reviewer: No cross-task issues remaining
+
+[Use superpowers:finishing-a-development-branch]
 Done!
 ```
 
@@ -233,6 +239,7 @@ Done!
 - **superpowers:using-git-worktrees** - REQUIRED: Set up isolated workspace before starting
 - **superpowers:writing-plans** - Creates the plan this skill executes
 - **superpowers:requesting-code-review** - Code review template for reviewer subagents
+- **superpowers:implementation-review** - Fresh-eyes review of entire feature after all tasks
 - **superpowers:finishing-a-development-branch** - Complete development after all tasks
 
 **Subagents should use:**


### PR DESCRIPTION
## Summary
- Adds new `implementation-review` skill that dispatches an opus-level reviewer against the full feature diff (base-branch..HEAD) to catch cross-task issues per-task reviews miss
- Updates `subagent-driven-development` to call `implementation-review` after all tasks complete (replaces generic "final code reviewer")
- Updates `executing-plans` to add implementation review as Step 5 before finishing-a-development-branch
- Updates `finishing-a-development-branch` cross-references

Addresses [obra/superpowers#291](https://github.com/obra/superpowers/issues/291)

## Test plan
- [x] RED: Created synthetic multi-task repo with 6 planted cross-task issues
- [x] Baseline (sonnet, standard code-reviewer): found 6 cross-task issues mixed with 8 general quality concerns
- [x] GREEN (opus, implementation-review prompt): found 10 cross-task issues, stayed focused, explained why per-task missed each
- [x] Verified all 3 modified skills have consistent cross-references

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>