### PR TITLE
feat: native task management, cross-session persistence, auto-clear handoff

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -117,6 +117,15 @@ The user then reconsiders the assumption entirely, saving implementation effort.
 - Invoke the writing-plans skill to create a detailed implementation plan
 - Do NOT invoke any other skill. writing-plans is the next step.
 
+## Native Task Integration
+
+Use Claude Code's native task management to track checklist progress:
+
+- **At skill start:** Call `TaskCreate` for each checklist item (explore context, challenge assumptions, ask questions, propose approaches, present design, write doc, transition)
+- **Set dependencies:** Each task should have `blockedBy` referencing the previous task, enforcing sequential completion
+- **During execution:** Call `TaskUpdate` to mark tasks `in_progress` when starting, `completed` when done
+- **Before handoff:** Call `TaskList` to verify all brainstorming tasks are complete before invoking writing-plans
+
 ## Key Principles
 
 - **Batch independent text questions** — up to 4 per AskUserQuestion call, multiple batches if more than 4

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -170,6 +170,16 @@ After agents return:
 3. **Run full suite** - Verify all fixes work together
 4. **Spot check** - Agents can make systematic errors
 
+## Native Task Integration
+
+Use Claude Code's native task management to track parallel agent work:
+
+- **Before dispatch:** Call `TaskCreate` for each agent's scope — one task per agent. Parallel tasks have NO `blockedBy` dependencies (they run concurrently).
+- **During execution:** Each agent's task should be marked `in_progress` before dispatch.
+- **After completion:** `TaskUpdate` each task to `completed` as agents return results.
+- **Monitoring:** Call `TaskList` to see which agents have completed and which are still running.
+- **Integration task:** Create a final `TaskCreate` with `blockedBy` referencing all agent tasks — this blocks until all agents finish, then you review and integrate results.
+
 ## Real-World Impact
 
 From debugging session (2025-10-03):

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -15,20 +15,31 @@ Load plan, review critically, execute tasks in batches, report for review betwee
 
 ## The Process
 
+### Step 0: Load Persisted Tasks
+
+Check for existing task state from a prior session:
+
+1. Call `TaskList` to check for existing native tasks
+2. If tasks exist: Resume from where the previous session left off — find the first non-completed task
+3. If no tasks: Look for `.tasks.json` co-located with the plan file (e.g. `docs/plans/.tasks.json`)
+4. If `.tasks.json` found: Recreate native tasks with `TaskCreate`, preserving `blockedBy` dependencies and marking already-completed tasks
+5. If neither exists: Bootstrap tasks from the plan (Step 1b below)
+
 ### Step 1: Load and Review Plan
 1. Read plan file
 2. Review critically - identify any questions or concerns about the plan
 3. If concerns: Raise them with your human partner before starting
-4. If no concerns: Create TodoWrite and proceed
+4. If no concerns and no tasks loaded from Step 0: Create tasks with `TaskCreate` for each plan task, setting `blockedBy` dependencies for sequential tasks (Step 1b)
 
 ### Step 2: Execute Batch
 **Default: First 3 tasks**
 
 For each task:
-1. Mark as in_progress
+1. `TaskUpdate` to mark as `in_progress`
 2. Follow each step exactly (plan has bite-sized steps)
 3. Run verifications as specified
-4. Mark as completed
+4. `TaskUpdate` to mark as `completed`
+5. Update `.tasks.json` with new status (enables cross-session resume)
 
 ### Step 3: Report
 When batch complete:

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -53,15 +53,16 @@ digraph process {
         "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [shape=box];
         "Code quality reviewer subagent approves?" [shape=diamond];
         "Implementer subagent fixes quality issues" [shape=box];
-        "Mark task complete in TodoWrite" [shape=box];
+        "TaskUpdate: mark task completed" [shape=box];
     }
 
-    "Read plan, extract all tasks with full text, note context, create TodoWrite" [shape=box];
+    "Read plan, extract all tasks with full text, note context, TaskCreate for each" [shape=box];
     "More tasks remain?" [shape=diamond];
     "Use superpowers:implementation-review for fresh-eyes review of entire feature" [shape=box];
     "Use superpowers:finishing-a-development-branch" [shape=box style=filled fillcolor=lightgreen];
 
-    "Read plan, extract all tasks with full text, note context, create TodoWrite" -> "Dispatch implementer subagent (./implementer-prompt.md)";
+    "Read plan, extract all tasks with full text, note context, TaskCreate for each" -> "TaskList to find next pending task";
+    "TaskList to find next pending task" -> "Dispatch implementer subagent (./implementer-prompt.md)";
     "Dispatch implementer subagent (./implementer-prompt.md)" -> "Implementer subagent asks questions?";
     "Implementer subagent asks questions?" -> "Answer questions, provide context" [label="yes"];
     "Answer questions, provide context" -> "Dispatch implementer subagent (./implementer-prompt.md)";
@@ -74,9 +75,9 @@ digraph process {
     "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" -> "Code quality reviewer subagent approves?";
     "Code quality reviewer subagent approves?" -> "Implementer subagent fixes quality issues" [label="no"];
     "Implementer subagent fixes quality issues" -> "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [label="re-review"];
-    "Code quality reviewer subagent approves?" -> "Mark task complete in TodoWrite" [label="yes"];
-    "Mark task complete in TodoWrite" -> "More tasks remain?";
-    "More tasks remain?" -> "Dispatch implementer subagent (./implementer-prompt.md)" [label="yes"];
+    "Code quality reviewer subagent approves?" -> "TaskUpdate: mark task completed" [label="yes"];
+    "TaskUpdate: mark task completed" -> "More tasks remain?";
+    "More tasks remain?" -> "TaskList to find next pending task" [label="yes"];
     "More tasks remain?" -> "Use superpowers:implementation-review for fresh-eyes review of entire feature" [label="no"];
     "Use superpowers:implementation-review for fresh-eyes review of entire feature" -> "Use superpowers:finishing-a-development-branch";
 }
@@ -95,7 +96,7 @@ You: I'm using Subagent-Driven Development to execute this plan.
 
 [Read plan file once: docs/plans/feature-plan.md]
 [Extract all 5 tasks with full text and context]
-[Create TodoWrite with all tasks]
+[Create TaskCreate/TaskUpdate with all tasks]
 
 Task 1: Hook installation script
 

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -33,7 +33,7 @@ digraph skill_flow {
     "Invoke Skill tool" [shape=box];
     "Announce: 'Using [skill] to [purpose]'" [shape=box];
     "Has checklist?" [shape=diamond];
-    "Create TodoWrite todo per item" [shape=box];
+    "TaskCreate for each checklist item" [shape=box];
     "Follow skill exactly" [shape=box];
     "Respond (including clarifications)" [shape=doublecircle];
 
@@ -47,9 +47,9 @@ digraph skill_flow {
     "Might any skill apply?" -> "Respond (including clarifications)" [label="definitely not"];
     "Invoke Skill tool" -> "Announce: 'Using [skill] to [purpose]'";
     "Announce: 'Using [skill] to [purpose]'" -> "Has checklist?";
-    "Has checklist?" -> "Create TodoWrite todo per item" [label="yes"];
+    "Has checklist?" -> "TaskCreate for each checklist item" [label="yes"];
     "Has checklist?" -> "Follow skill exactly" [label="no"];
-    "Create TodoWrite todo per item" -> "Follow skill exactly";
+    "TaskCreate for each checklist item" -> "Follow skill exactly";
 }
 ```
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -17,6 +17,10 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Save plans to:** `docs/plans/YYYY-MM-DD-<feature-name>.md`
 
+## REQUIRED FIRST STEP: Initialize Task Tracking
+
+Before any exploration or planning, call `TaskList` to check for existing tasks from a prior session. Then call `TaskCreate` for each major planning phase (explore codebase, write tasks, save plan, handoff).
+
 ## Bite-Sized Task Granularity
 
 **Each step is one action (2-5 minutes):**
@@ -94,22 +98,71 @@ git commit -m "feat: add specific feature"
 - Reference relevant skills with @ syntax
 - DRY, YAGNI, TDD, frequent commits
 
+## Task Persistence
+
+After saving the plan, write a `.tasks.json` file co-located with the plan document. This enables cross-session resume:
+
+```json
+{
+  "planFile": "docs/plans/YYYY-MM-DD-feature-name.md",
+  "createdAt": "ISO-8601 timestamp",
+  "tasks": [
+    {
+      "id": 1,
+      "title": "Task 1: Component Name",
+      "status": "pending",
+      "blockedBy": []
+    },
+    {
+      "id": 2,
+      "title": "Task 2: Next Component",
+      "status": "pending",
+      "blockedBy": [1]
+    }
+  ]
+}
+```
+
+**File location:** Same directory as the plan, e.g. `docs/plans/.tasks.json`
+
+When tasks are completed during execution, the executing skill updates this file so progress survives session boundaries.
+
 ## Execution Handoff
 
-After saving the plan, offer execution choice:
+<HARD-GATE>
+After saving the plan and `.tasks.json`, use `AskUserQuestion` to present the execution choice. Do NOT proceed to implementation without an explicit answer.
+</HARD-GATE>
 
-**"Plan complete and saved to `docs/plans/<filename>.md`. Two execution options:**
+Use `AskUserQuestion` with these options:
 
-**1. Subagent-Driven (this session)** - I dispatch fresh subagent per task, review between tasks, fast iteration
+**Question:** "Plan saved to `docs/plans/<filename>.md`. How would you like to execute?"
 
-**2. Parallel Session (separate)** - Open new session with executing-plans, batch execution with checkpoints
+**Option 1: Subagent-Driven (this session)**
+- Description: "Dispatch an Opus orchestrator subagent with fresh context to run subagent-driven-development. Fast iteration, two-stage review per task."
 
-**Which approach?"**
+**Option 2: Parallel Session (separate)**
+- Description: "Open a new session in the worktree directory and use executing-plans. Batch execution with human checkpoints between batches."
+
+**After user answers:**
 
 **If Subagent-Driven chosen:**
-- **REQUIRED SUB-SKILL:** Use superpowers:subagent-driven-development
-- Stay in this session
-- Fresh subagent per task + code review
+
+Dispatch a fresh **Opus** orchestrator subagent via the `Task` tool with `model: "opus"`. The orchestrator starts with zero prior context — all planning baggage stays in the parent. This is the automatic equivalent of `/clear` before execution.
+
+The orchestrator prompt MUST include:
+1. The full path to the plan file (e.g. `docs/plans/YYYY-MM-DD-feature.md`)
+2. The working directory (worktree path)
+3. Instruction to use `superpowers:subagent-driven-development` skill
+4. Instruction to use `superpowers:finishing-a-development-branch` when complete
+
+Example Task dispatch:
+```
+Task(
+  description: "Execute implementation plan",
+  model: "opus",
+  prompt: "You are an orchestrator. Read the plan at docs/plans/<filename>.md and execute it using the superpowers:subagent-driven-development skill. When all tasks are complete, use superpowers:finishing-a-development-branch to wrap up. Working directory: <worktree-path>"
+)
+```
 
 **If Parallel Session chosen:**
 - Guide them to open new session in worktree

--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -595,7 +595,7 @@ Deploying untested skills = deploying untested code. It's a violation of quality
 
 ## Skill Creation Checklist (TDD Adapted)
 
-**IMPORTANT: Use TodoWrite to create todos for EACH checklist item below.**
+**IMPORTANT: Use TaskCreate to create a task for EACH checklist item below.**
 
 **RED Phase - Write Failing Test:**
 - [ ] Create pressure scenarios (3+ combined pressures for discipline skills)

--- a/skills/writing-skills/persuasion-principles.md
+++ b/skills/writing-skills/persuasion-principles.md
@@ -33,7 +33,7 @@ LLMs respond to the same persuasion principles as humans. Understanding this psy
 **How it works in skills:**
 - Require announcements: "Announce skill usage"
 - Force explicit choices: "Choose A, B, or C"
-- Use tracking: TodoWrite for checklists
+- Use tracking: TaskCreate/TaskUpdate for checklists
 
 **When to use:**
 - Ensuring skills are actually followed
@@ -80,8 +80,8 @@ LLMs respond to the same persuasion principles as humans. Understanding this psy
 
 **Example:**
 ```markdown
-✅ Checklists without TodoWrite tracking = steps get skipped. Every time.
-❌ Some people find TodoWrite helpful for checklists.
+✅ Checklists without TaskCreate tracking = steps get skipped. Every time.
+❌ Some people find task tracking helpful for checklists.
 ```
 
 ### 5. Unity


### PR DESCRIPTION
## Summary
- Replace `TodoWrite` with Claude Code native `TaskCreate`/`TaskUpdate`/`TaskList` across all 8 workflow skills, adding dependency enforcement via `blockedBy` and runtime visibility
- Add `.tasks.json` cross-session persistence so task progress survives session boundaries — `writing-plans` writes it, `executing-plans` reads it on resume
- Replace manual `/clear` execution handoff with automatic Opus orchestrator subagent dispatch that starts with zero planning context

## Test plan
- [ ] Verify brainstorming skill creates native tasks for each checklist item
- [ ] Verify writing-plans produces `.tasks.json` alongside plan file
- [ ] Verify executing-plans Step 0 resumes from `.tasks.json` in a new session
- [ ] Verify subagent-driven-development flowchart uses TaskCreate/TaskUpdate (no TodoWrite refs)
- [ ] Verify AskUserQuestion handoff dispatches Opus orchestrator on "Subagent-Driven" choice
- [ ] Grep for stale `TodoWrite` references in skills/ (should be zero)

Co-Authored-By: Claude <noreply@anthropic.com>