### PR TITLE
feat: add plan-review skill for pre-execution consistency validation

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -25,6 +25,15 @@ Check for existing task state from a prior session:
 4. If `.tasks.json` found: Recreate native tasks with `TaskCreate`, preserving `blockedBy` dependencies and marking already-completed tasks
 5. If neither exists: Bootstrap tasks from the plan (Step 1b below)
 
+### Step 0.5: Verify Plan Review
+
+Before executing, confirm the plan has passed superpowers:plan-review:
+1. Check if a plan review was already run (ask user or check conversation context)
+2. If NOT reviewed: **REQUIRED SUB-SKILL:** Run superpowers:plan-review before proceeding
+3. If reviewed and passed: Continue to Step 1
+
+**Do NOT skip this.** Executing an unreviewed plan wastes implementation effort on inconsistencies that are cheap to fix in the plan.
+
 ### Step 1: Load and Review Plan
 1. Read plan file
 2. Review critically - identify any questions or concerns about the plan
@@ -99,5 +108,6 @@ After implementation review passes:
 **Required workflow skills:**
 - **superpowers:using-git-worktrees** - REQUIRED: Set up isolated workspace before starting
 - **superpowers:writing-plans** - Creates the plan this skill executes
+- **superpowers:plan-review** - Validates plan consistency before execution begins
 - **superpowers:implementation-review** - Fresh-eyes review of entire feature after all batches
 - **superpowers:finishing-a-development-branch** - Complete development after all tasks

--- a/skills/plan-review/SKILL.md
+++ b/skills/plan-review/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: plan-review
+description: Use when a plan has been written and before execution begins, to catch internal inconsistencies, design doc mismatches, and missing dependencies that would waste implementation effort
+---
+
+# Plan Review
+
+## Overview
+
+Dispatch an Opus subagent to review a written plan for internal consistency and alignment with the design doc before any code gets written. Catches issues that are cheap to fix in a plan but expensive to fix mid-implementation.
+
+**Core principle:** Plans are hypotheses about how to build something. Validate the hypothesis before running the experiment.
+
+**Announce at start:** "I'm using the plan-review skill to validate this plan before execution."
+
+## When to Use
+
+- After writing-plans produces a plan document
+- Before executing-plans or subagent-driven-development begins
+- When resuming work on a plan that's been idle (context may have drifted)
+
+**Not needed for:** Single-task plans, hotfix plans, plans with no design doc reference.
+
+## The Process
+
+```dot
+digraph process {
+    rankdir=TB;
+    "Locate plan file and design doc" [shape=box];
+    "Dispatch Opus reviewer with ./reviewer-prompt.md" [shape=box];
+    "Issues found?" [shape=diamond];
+    "Fix plan (not code)" [shape=box];
+    "Re-run plan review" [shape=box];
+    "Proceed to execution" [shape=box style=filled fillcolor=lightgreen];
+
+    "Locate plan file and design doc" -> "Dispatch Opus reviewer with ./reviewer-prompt.md";
+    "Dispatch Opus reviewer with ./reviewer-prompt.md" -> "Issues found?";
+    "Issues found?" -> "Fix plan (not code)" [label="yes"];
+    "Fix plan (not code)" -> "Re-run plan review" [label="re-review"];
+    "Re-run plan review" -> "Issues found?";
+    "Issues found?" -> "Proceed to execution" [label="no"];
+}
+```
+
+## How to Dispatch
+
+Gather inputs:
+- **Plan file path** — e.g. `docs/plans/2026-02-25-feature.md`
+- **Design doc path** — if one exists (from brainstorming or prior work)
+- **Codebase root** — the repo/worktree the plan targets
+
+Then dispatch using `./reviewer-prompt.md` template with:
+- `{PLAN_PATH}` — path to the plan document
+- `{DESIGN_DOC_PATH}` — path to design doc (or "None" if no design doc)
+- `{REPO_PATH}` — codebase root for verifying file paths against existing code
+
+**Critical:** Always use `model: "opus"` for the reviewer subagent. Consistency checking requires strong reasoning to trace dependencies across tasks.
+
+## What It Catches
+
+| Category | Example | Why the Planner Misses It |
+|----------|---------|--------------------------|
+| Dependency ordering | Task 4 imports a util created in Task 6 | Planner thinks about tasks as units, not their sequencing |
+| File path drift | Task 2 creates `src/utils.ts`, Task 5 imports from `src/helpers.ts` | Renaming during planning without updating all references |
+| Design doc mismatch | Design says REST API, plan implements GraphQL | Plan diverged from design during task decomposition |
+| Missing tasks | Design specifies auth middleware, plan has no auth task | Scope items lost during decomposition |
+| Phantom dependencies | Task tests a function that no task ever creates | Copy-paste from similar plan, not adapted |
+| Inconsistent naming | `UserService` in one task, `userService` in another | Each task written in isolation |
+| Impossible test expectations | Test expects return value X but implementation returns Y | Test and implementation steps written at different times |
+| Tech stack contradictions | Plan header says SQLite, Task 3 uses PostgreSQL syntax | Header written first, tasks written later with different assumptions |
+
+## Red Flags
+
+**Never:**
+- Skip this because "the plan looks fine" (that's what the planner always thinks)
+- Fix issues by editing code (there is no code yet — fix the plan)
+- Let minor issues slide (they compound during implementation)
+
+**If reviewer finds issues:**
+- Fix the plan document
+- Update `.tasks.json` if task structure changed
+- Re-run review after fixes
+- Don't skip re-review
+
+## Integration
+
+**Called by:**
+- **superpowers:writing-plans** — after plan is saved, before execution handoff
+
+**Leads to:**
+- **superpowers:executing-plans** — once review passes
+- **superpowers:subagent-driven-development** — once review passes

--- a/skills/plan-review/reviewer-prompt.md
+++ b/skills/plan-review/reviewer-prompt.md
@@ -1,0 +1,133 @@
+# Plan Review Prompt Template
+
+Use this template when dispatching an Opus reviewer subagent to validate a plan before execution.
+
+**Purpose:** Catch internal inconsistencies, design doc mismatches, and missing dependencies before any code gets written.
+
+**Only dispatch after the plan is fully written and saved.**
+
+```
+Task tool (general-purpose):
+  model: "opus"
+  description: "Plan consistency review"
+  prompt: |
+    You are reviewing an implementation plan BEFORE any code is written.
+    Your job: find every inconsistency, missing dependency, and design
+    mismatch that would cause problems during implementation.
+
+    ## Plan File
+
+    Read the full plan at: {PLAN_PATH}
+
+    ## Design Doc
+
+    {DESIGN_DOC_PATH}
+    (If "None": skip design doc checks, focus on internal consistency only)
+
+    ## Codebase
+
+    The plan targets the codebase at: {REPO_PATH}
+    Read existing files as needed to verify paths, imports, and assumptions.
+
+    ## Review Checklist
+
+    Work through each category systematically. For each, read ALL tasks
+    in the plan and cross-reference.
+
+    ### 1. Dependency Ordering
+    For each task, list what it USES (imports, calls, extends) and what
+    it CREATES (files, functions, classes, types). Verify that everything
+    a task USES is CREATED by a prior task or already exists in the codebase.
+
+    Flag: Task N uses X, but X is created in Task M where M > N.
+    Flag: Task N uses X, but no task creates X and it doesn't exist in the codebase.
+
+    ### 2. File Path Consistency
+    Extract every file path mentioned across all tasks. Group by intended
+    file. Verify the same file is referenced with the same path everywhere.
+
+    Flag: Same logical file referenced with different paths across tasks.
+    Flag: File path in plan doesn't match existing codebase conventions.
+
+    ### 3. Design Doc Alignment (skip if no design doc)
+    Compare the plan's scope against the design doc's requirements:
+    - Every design doc requirement should map to at least one task
+    - Plan's architecture should match design doc's architecture
+    - Tech stack should be consistent
+    - Data models / schemas should match
+
+    Flag: Design doc specifies X but no task implements it.
+    Flag: Plan uses approach A but design doc specifies approach B.
+
+    ### 4. Naming Consistency
+    Track every named entity (functions, classes, variables, config keys,
+    API endpoints) across all tasks. Verify consistent naming.
+
+    Flag: Same concept with different names in different tasks.
+    Flag: Name in test doesn't match name in implementation step.
+
+    ### 5. Test-Implementation Coherence
+    For each task that has test steps and implementation steps:
+    - Does the test import from the correct path?
+    - Does the test call functions with the correct signature?
+    - Does the test expect return values consistent with the implementation?
+    - Would the test actually fail before implementation (as TDD requires)?
+
+    Flag: Test expects function(a, b) but implementation defines function(a, b, c).
+    Flag: Test asserts return value X but implementation returns Y.
+
+    ### 6. Completeness
+    - Does every "Create" file get populated by some task's implementation step?
+    - Does every "Modify" file actually exist (check codebase)?
+    - Are there tasks that create files but no task ever imports/uses them?
+    - Does the plan cover error handling, edge cases, or config that the
+      design doc specifies?
+
+    Flag: File listed in "Create" but never populated with code.
+    Flag: "Modify: path/to/file.py:123-145" but file doesn't exist or has fewer lines.
+
+    ### 7. Command Correctness
+    - Do test commands reference the correct test file paths?
+    - Do commit commands stage the right files?
+    - Are build/run commands consistent with the project's tooling?
+
+    Flag: `pytest tests/path/test.py` but test file is at different path.
+    Flag: `npm test` but project uses `yarn` or `pnpm`.
+
+    ## Output Format
+
+    ### Issues Found
+
+    For each issue:
+    - **Category** (1-7 from above)
+    - **Tasks involved** (Task N, Task M)
+    - **What's wrong** (specific, with quotes from the plan)
+    - **Suggested fix**
+
+    ### Consistency Matrix (summary)
+
+    | Check | Status | Notes |
+    |-------|--------|-------|
+    | Dependency ordering | PASS/FAIL | |
+    | File path consistency | PASS/FAIL | |
+    | Design doc alignment | PASS/FAIL/SKIPPED | |
+    | Naming consistency | PASS/FAIL | |
+    | Test-implementation coherence | PASS/FAIL | |
+    | Completeness | PASS/FAIL | |
+    | Command correctness | PASS/FAIL | |
+
+    ### Assessment
+
+    **Issues found:** [count]
+    **Severity:** [Critical / Important / Minor for each]
+    **Ready for execution?** [Yes / Yes after fixes / No, needs rework]
+
+    ## Critical Rules
+
+    - DO NOT review code style or testing philosophy — this is a consistency check
+    - DO trace dependencies across tasks — this is the primary value
+    - Be specific: quote the plan, reference task numbers
+    - If you find zero issues, say so — don't invent problems
+    - DO NOT modify any files. Read-only review.
+    - DO check existing codebase files when the plan references them
+```

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -127,15 +127,32 @@ After saving the plan, write a `.tasks.json` file co-located with the plan docum
 
 When tasks are completed during execution, the executing skill updates this file so progress survives session boundaries.
 
+## Plan Review (Required)
+
+<HARD-GATE>
+After saving the plan and `.tasks.json`, run plan-review BEFORE offering execution options. Do NOT skip this step. Do NOT proceed to execution without a passing review.
+</HARD-GATE>
+
+**REQUIRED SUB-SKILL:** Use superpowers:plan-review to validate the plan.
+
+Provide the reviewer with:
+- The plan file path
+- The design doc path (if one exists from brainstorming)
+- The codebase root (worktree path)
+
+**If issues found:** Fix the plan, update `.tasks.json` if structure changed, re-run review.
+
+**If clean:** Proceed to execution handoff.
+
 ## Execution Handoff
 
 <HARD-GATE>
-After saving the plan and `.tasks.json`, use `AskUserQuestion` to present the execution choice. Do NOT proceed to implementation without an explicit answer.
+After plan review passes, use `AskUserQuestion` to present the execution choice. Do NOT proceed to implementation without an explicit answer.
 </HARD-GATE>
 
 Use `AskUserQuestion` with these options:
 
-**Question:** "Plan saved to `docs/plans/<filename>.md`. How would you like to execute?"
+**Question:** "Plan reviewed and validated. Saved to `docs/plans/<filename>.md`. How would you like to execute?"
 
 **Option 1: Subagent-Driven (this session)**
 - Description: "Dispatch an Opus orchestrator subagent with fresh context to run subagent-driven-development. Fast iteration, two-stage review per task."


### PR DESCRIPTION
## Summary
- Adds new `plan-review` skill that dispatches an Opus subagent to validate plans before execution begins
- Reviewer checks 7 categories: dependency ordering, file path consistency, design doc alignment, naming consistency, test-implementation coherence, completeness, and command correctness
- Gates writing-plans on plan-review before execution handoff (HARD-GATE)
- Adds Step 0.5 to executing-plans to verify plan was reviewed

## Test plan
- [ ] Verify plan-review skill is discoverable via skill search
- [ ] Run writing-plans end-to-end and confirm plan-review gate fires before execution handoff
- [ ] Run executing-plans on a reviewed plan and confirm Step 0.5 passes
- [ ] Run plan-review on a plan with known inconsistencies and verify they're caught

Co-Authored-By: Claude <noreply@anthropic.com>