### PR TITLE
feat(skills): add anti-drift mechanisms with mandatory completeness and deviation rules

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -76,10 +76,31 @@ After implementation review passes:
 - **REQUIRED SUB-SKILL:** Use superpowers:finishing-a-development-branch
 - Follow that skill to verify tests, present options, execute choice
 
+## Deviation Rules
+
+When reality diverges from the plan, follow these rules in order:
+
+| Rule | Trigger | Action | Permission |
+|------|---------|--------|------------|
+| **Rule 1: Auto-fix bugs** | Code doesn't work as intended | Fix inline, commit, document | No user permission needed |
+| **Rule 2: Auto-add missing critical** | Missing error handling, validation, auth | Fix inline, commit, document | No user permission needed |
+| **Rule 3: Auto-fix blockers** | Missing dep, broken import, wrong types | Fix inline, commit, document | No user permission needed |
+| **Rule 4: STOP for architectural changes** | New DB table, library swap, breaking API change | **Stop and ask user** | Requires explicit user decision |
+
+**Scope boundary:** Only auto-fix issues directly caused by the current task's changes. Pre-existing issues go to a deferred list — note them in the batch report but don't fix them.
+
+**Fix attempt limit:** After 3 auto-fix attempts on a single issue, stop and document the remaining problem. Don't loop indefinitely.
+
+**Documentation:** For every Rule 1-3 deviation, include in the batch report:
+- What deviated from the plan
+- What was done to fix it
+- Which rule applied
+
 ## When to Stop and Ask for Help
 
 **STOP executing immediately when:**
-- Hit a blocker mid-batch (missing dependency, test fails, instruction unclear)
+- Rule 4 deviation (architectural change needed)
+- Hit a blocker mid-batch after 3 fix attempts
 - Plan has critical gaps preventing starting
 - You don't understand an instruction
 - Verification fails repeatedly

--- a/skills/plan-review/SKILL.md
+++ b/skills/plan-review/SKILL.md
@@ -68,6 +68,8 @@ Then dispatch using `./reviewer-prompt.md` template with:
 | Inconsistent naming | `UserService` in one task, `userService` in another | Each task written in isolation |
 | Impossible test expectations | Test expects return value X but implementation returns Y | Test and implementation steps written at different times |
 | Tech stack contradictions | Plan header says SQLite, Task 3 uses PostgreSQL syntax | Header written first, tasks written later with different assumptions |
+| Implied context | Task says "modify the auth handler" without specifying file | Planner has conversation context that won't exist during execution |
+| Missing mandatory fields | Task has no verification command or measurable done criteria | Planner assumes executor will figure it out |
 
 ## Red Flags
 

--- a/skills/plan-review/reviewer-prompt.md
+++ b/skills/plan-review/reviewer-prompt.md
@@ -94,6 +94,22 @@ Task tool (general-purpose):
     Flag: `pytest tests/path/test.py` but test file is at different path.
     Flag: `npm test` but project uses `yarn` or `pnpm`.
 
+    ### 8. "Different Claude" Test
+    For each task, evaluate: could a fresh Claude instance with ZERO
+    conversation history execute this task unambiguously?
+
+    Check each task for:
+    - Missing mandatory fields (Files, Verification, Done criteria, Avoid)
+    - Implied context not written down ("the function we discussed")
+    - Vague references ("update the config", "fix the handler")
+    - Missing file paths or partial paths
+    - Done criteria that aren't measurable
+
+    Flag: Task N says "modify the auth handler" but doesn't specify which file.
+    Flag: Task N has no verification command.
+    Flag: Task N's done criteria is "auth works" (not measurable).
+    Flag: Task N references context from conversation, not from the plan itself.
+
     ## Output Format
 
     ### Issues Found
@@ -115,6 +131,7 @@ Task tool (general-purpose):
     | Test-implementation coherence | PASS/FAIL | |
     | Completeness | PASS/FAIL | |
     | Command correctness | PASS/FAIL | |
+    | "Different Claude" test | PASS/FAIL | |
 
     ### Assessment
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -203,6 +203,28 @@ Done!
 - Review loops add iterations
 - But catches issues early (cheaper than debugging later)
 
+## Deviation Rules
+
+When reality diverges from the plan, follow these rules in order:
+
+| Rule | Trigger | Action | Permission |
+|------|---------|--------|------------|
+| **Rule 1: Auto-fix bugs** | Code doesn't work as intended | Fix inline, commit, document | No user permission needed |
+| **Rule 2: Auto-add missing critical** | Missing error handling, validation, auth | Fix inline, commit, document | No user permission needed |
+| **Rule 3: Auto-fix blockers** | Missing dep, broken import, wrong types | Fix inline, commit, document | No user permission needed |
+| **Rule 4: STOP for architectural changes** | New DB table, library swap, breaking API change | **Stop and ask user** | Requires explicit user decision |
+
+**Scope boundary:** Only auto-fix issues directly caused by the current task's changes. Pre-existing issues go to a deferred list — note them in the task completion report but don't fix them.
+
+**Fix attempt limit:** After 3 auto-fix attempts on a single issue, stop and document the remaining problem. Don't loop indefinitely.
+
+**Documentation:** For every Rule 1-3 deviation, the implementer subagent must include in its completion report:
+- What deviated from the plan
+- What was done to fix it
+- Which rule applied
+
+The orchestrator includes deviation summaries in the final report.
+
 ## Red Flags
 
 **Never:**

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -50,6 +50,8 @@ Before any exploration or planning, call `TaskList` to check for existing tasks 
 
 ## Task Structure
 
+Every task MUST include ALL of the following fields. Missing fields = incomplete plan.
+
 ````markdown
 ### Task N: [Component Name]
 
@@ -57,6 +59,14 @@ Before any exploration or planning, call `TaskList` to check for existing tasks 
 - Create: `exact/path/to/file.py`
 - Modify: `exact/path/to/existing.py:123-145`
 - Test: `tests/exact/path/to/test.py`
+
+**Verification:** `pytest tests/path/test.py -v` (must complete in <60s)
+
+**Done when:** [Measurable state — not "it works" or "authentication complete"]
+Example: "POST /api/auth/login returns 200 with valid JWT; 401 with invalid credentials; test_login_* 4/4 passing"
+
+**Avoid:** [What NOT to do + WHY]
+Example: "Use jose not jsonwebtoken — CommonJS issues with Edge runtime"
 
 **Step 1: Write the failing test**
 
@@ -91,12 +101,46 @@ git commit -m "feat: add specific feature"
 ```
 ````
 
+### Mandatory Task Field Checklist
+
+Before saving the plan, verify EVERY task has:
+
+| Field | Requirement | Bad Example | Good Example |
+|-------|-------------|-------------|--------------|
+| **Files** | Exact paths (create/modify/test) | "the auth files" | `src/auth/login.ts`, `tests/auth/login.test.ts` |
+| **Verification** | Automated, runnable, <60s | "check that it works" | `pytest tests/auth/ -v` |
+| **Done when** | Measurable end state | "authentication complete" | "login returns JWT, 4/4 tests pass" |
+| **Avoid + WHY** | Pitfalls with reasoning | "don't use X" | "Use jose not jsonwebtoken — CJS/Edge issues" |
+
+### Specificity Quality Bar
+
+> Could a fresh Claude instance with zero prior context execute this task without asking a single clarifying question? If not, add specificity.
+
+## Interface-First Task Ordering
+
+When a plan creates interfaces consumed by later tasks:
+
+1. **First task:** Define contracts (types, interfaces, exports) — embed the contract text in the plan itself
+2. **Middle tasks:** Implement against contracts
+3. **Last task:** Wire implementations to consumers
+
+Embed the contract in the plan so executors don't need to explore the codebase to understand dependencies.
+
+Example ordering:
+```
+Task 1: Define UserService interface and types     ← contract
+Task 2: Implement UserService against interface     ← implements contract
+Task 3: Implement UserRepository against interface  ← implements contract
+Task 4: Wire UserService into API routes            ← consumes implementations
+```
+
 ## Remember
 - Exact file paths always
 - Complete code in plan (not "add validation")
 - Exact commands with expected output
 - Reference relevant skills with @ syntax
 - DRY, YAGNI, TDD, frequent commits
+- Every task passes the "fresh Claude" specificity test
 
 ## Task Persistence
 


### PR DESCRIPTION
## Summary
- Add mandatory task field checklist (Files, Verification, Done criteria, Avoid+WHY) with specificity quality bar and interface-first ordering guidance to `writing-plans`
- Add "Different Claude" test as review check #8 to `plan-review` reviewer prompt and consistency matrix
- Add deviation rules (Rules 1-3 auto-fix, Rule 4 stop-for-architectural) with scope boundary and 3-attempt limit to `executing-plans` and `subagent-driven-development`

## Test plan
- [ ] Verify writing-plans task template includes all four mandatory fields
- [ ] Verify plan-review reviewer-prompt.md has check #8 and updated consistency matrix
- [ ] Verify executing-plans deviation rules table and updated "When to Stop" section
- [ ] Verify subagent-driven-development deviation rules with implementer/orchestrator reporting

Closes #7

Co-Authored-By: Claude <noreply@anthropic.com>