### PR TITLE
feat(skills): enforce TDD and add integration testing to review

### DIFF
--- a/skills/implementation-review/SKILL.md
+++ b/skills/implementation-review/SKILL.md
@@ -7,7 +7,7 @@ description: Use when a multi-task implementation is complete and ready for holi
 
 Review the entire feature implementation with fresh eyes, focusing on issues that only surface when looking at all tasks together.
 
-**Core principle:** Per-task reviews verify each piece works. Implementation review verifies the pieces work together.
+**Core principle:** Per-task reviews verify each piece works. Implementation review verifies the pieces work together — through both code review and integration tests.
 
 ## When to Use
 
@@ -25,6 +25,7 @@ digraph process {
     rankdir=TB;
     "Get base branch SHA (origin/main or where feature diverged)" [shape=box];
     "Get HEAD SHA (current commit)" [shape=box];
+    "Write integration tests for cross-boundary interactions" [shape=box];
     "Dispatch reviewer subagent with ./reviewer-prompt.md" [shape=box];
     "Reviewer finds issues?" [shape=diamond];
     "Fix issues (dispatch implementer or fix directly)" [shape=box];
@@ -32,7 +33,8 @@ digraph process {
     "Proceed to superpowers:finishing-a-development-branch" [shape=box style=filled fillcolor=lightgreen];
 
     "Get base branch SHA (origin/main or where feature diverged)" -> "Get HEAD SHA (current commit)";
-    "Get HEAD SHA (current commit)" -> "Dispatch reviewer subagent with ./reviewer-prompt.md";
+    "Get HEAD SHA (current commit)" -> "Write integration tests for cross-boundary interactions";
+    "Write integration tests for cross-boundary interactions" -> "Dispatch reviewer subagent with ./reviewer-prompt.md";
     "Dispatch reviewer subagent with ./reviewer-prompt.md" -> "Reviewer finds issues?";
     "Reviewer finds issues?" -> "Fix issues (dispatch implementer or fix directly)" [label="yes"];
     "Fix issues (dispatch implementer or fix directly)" -> "Re-run implementation review" [label="re-review"];
@@ -40,6 +42,18 @@ digraph process {
     "Reviewer finds issues?" -> "Proceed to superpowers:finishing-a-development-branch" [label="no"];
 }
 ```
+
+## Integration Tests (Before Review)
+
+After all tasks complete but before dispatching the reviewer, write integration tests that verify cross-boundary interactions:
+
+1. **Identify boundaries** — look at which tasks produce outputs consumed by other tasks (shared config, module interfaces, data flows)
+2. **Write tests at the seams** — test real interactions, not mocked ones. Integration tests should exercise the actual code paths between components.
+3. **Commit the integration tests** — they become part of the diff the reviewer evaluates
+
+**Skip integration tests when:** single-module change, no cross-task data flow, or purely additive tasks with no interactions (e.g., adding independent utility functions).
+
+The reviewer will then assess whether integration test coverage is adequate and flag gaps.
 
 ## How to Dispatch
 
@@ -70,6 +84,7 @@ Then dispatch using `./reviewer-prompt.md` template with:
 | Dead code from iteration | Conditional where both branches are identical | Emerged from incremental changes across tasks |
 | Documentation gaps | Feature supported in one module but not another, undocumented | Per-task reviewer sees one side |
 | Unclear/inconsistent errors | Multiple modules throw same generic message | Each reviewer sees one throw site |
+| Missing integration tests | Components interact but no test verifies the interaction | Each task only unit-tests its own piece |
 
 ## Red Flags
 

--- a/skills/implementation-review/reviewer-prompt.md
+++ b/skills/implementation-review/reviewer-prompt.md
@@ -82,6 +82,12 @@ Task tool (general-purpose):
        - Return values computed but never used by callers
        - Interfaces defined in one task but not implemented where needed
 
+    7. **Inadequate integration test coverage**
+       - Cross-boundary interactions that the integration tests don't cover
+       - Integration tests that mock away the very boundaries they should verify
+       - Data flows through multiple modules where the integration test only checks part of the path
+       - Configuration consumed by multiple modules with no test that validates the full path
+
     ## How to Review
 
     1. Read the full diff to understand the feature as a whole
@@ -95,15 +101,26 @@ Task tool (general-purpose):
     ### Cross-Task Issues Found
 
     For each issue:
-    - **Category** (from the 6 above)
+    - **Category** (from the 7 above)
     - **Files involved** (with line references)
     - **What's wrong**
     - **Why per-task review missed it**
     - **Suggested fix**
 
+    ### Integration Test Coverage Assessment
+
+    Review the integration tests that were written before this review.
+    For each cross-boundary interaction in the feature:
+    - **Interaction**: Which components/modules connect
+    - **Covered?**: Yes/No — is there an integration test for this?
+    - **If gap**: What's missing and why it matters
+
+    If integration test coverage is adequate, write "Integration test coverage is adequate — [brief rationale]."
+
     ### Assessment
 
     **Issues found:** [count]
+    **Integration test gaps:** [count]
     **Severity:** [Critical / Important / Minor for each]
     **Ready to merge after fixing these?** [Yes/No]
 

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -30,8 +30,8 @@ Task tool (general-purpose):
     ## Your Job
 
     Once you're clear on requirements:
-    1. Implement exactly what the task specifies
-    2. Write tests (following TDD if task says to)
+    1. Invoke the `superpowers:test-driven-development` skill — follow it for all implementation
+    2. Implement exactly what the task specifies using TDD (red/green/refactor)
     3. Verify implementation works
     4. Commit your work
     5. Self-review (see below)
@@ -63,7 +63,7 @@ Task tool (general-purpose):
 
     **Testing:**
     - Do tests actually verify behavior (not just mock behavior)?
-    - Did I follow TDD if required?
+    - Did I follow TDD (red/green/refactor)?
     - Are tests comprehensive?
 
     If you find issues during self-review, fix them now before reporting.


### PR DESCRIPTION
## Summary
- Make TDD unconditional in implementer subagents — invoke the TDD skill as step 1, not conditionally based on plan text
- Add integration test writing step to implementation-review workflow, before the reviewer is dispatched
- Reviewer now evaluates integration test coverage adequacy with a dedicated output section (category 7)

## Test plan
- [ ] Run a multi-task feature through subagent-driven-development and verify implementer subagents invoke the TDD skill
- [ ] Run implementation-review on a multi-task branch and verify integration tests are written before reviewer dispatch
- [ ] Verify reviewer output includes "Integration Test Coverage Assessment" section

Co-Authored-By: Claude <noreply@anthropic.com>