### PR TITLE
chore(skills): trim descriptions, fix references, remove @ prefixes

### DIFF
--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: receiving-code-review
-description: Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation
+description: Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable
 ---
 
 # Code Review Reception

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -35,7 +35,7 @@ Use Task tool with superpowers:code-reviewer type, fill template at `code-review
 
 **Placeholders:**
 - `{WHAT_WAS_IMPLEMENTED}` - What you just built
-- `{PLAN_OR_REQUIREMENTS}` - What it should do
+- `{PLAN_REFERENCE}` - What it should do
 - `{BASE_SHA}` - Starting commit
 - `{HEAD_SHA}` - Ending commit
 - `{DESCRIPTION}` - Brief summary
@@ -58,7 +58,7 @@ HEAD_SHA=$(git rev-parse HEAD)
 
 [Dispatch superpowers:code-reviewer subagent]
   WHAT_WAS_IMPLEMENTED: Verification and repair functions for conversation index
-  PLAN_OR_REQUIREMENTS: Task 2 from docs/plans/deployment-plan.md
+  PLAN_REFERENCE: Task 2 from docs/plans/deployment-plan.md
   BASE_SHA: a7981ec
   HEAD_SHA: 3df7661
   DESCRIPTION: Added verifyIndex() and repairIndex() with 4 issue types

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -374,11 +374,11 @@ test('repository queries return users from real database adapter', () => {
 });
 ```
 
-See @testing-anti-patterns.md Anti-Pattern 5 for the full three-level framework and boundary test gate function.
+See testing-anti-patterns.md Anti-Pattern 5 for the full three-level framework and boundary test gate function.
 
 ## Testing Anti-Patterns
 
-When adding mocks or test utilities, read @testing-anti-patterns.md to avoid common pitfalls:
+When adding mocks or test utilities, read testing-anti-patterns.md to avoid common pitfalls:
 - Testing mock behavior instead of real behavior
 - Adding test-only methods to production classes
 - Mocking without understanding dependencies

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-superpowers
-description: Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions
+description: Use when starting any conversation, before any response or action including clarifying questions
 ---
 
 <EXTREMELY-IMPORTANT>
@@ -77,7 +77,7 @@ These thoughts mean STOP—you're rationalizing:
 When multiple skills could apply, use this order:
 
 1. **Process skills first** (brainstorming, debugging) - these determine HOW to approach the task
-2. **Implementation skills second** (frontend-design, mcp-builder) - these guide execution
+2. **Implementation skills second** (domain-specific skills) - these guide execution
 
 "Let's build X" → brainstorming first, then implementation skills.
 "Fix this bug" → debugging first, then domain-specific skills.

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verification-before-completion
-description: Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence before assertions always
+description: Use when about to claim work is complete, fixed, or passing, before committing or creating PRs
 ---
 
 # Verification Before Completion


### PR DESCRIPTION
## Summary
- Trim skill descriptions to triggering conditions only per CSO guidance (receiving-code-review, using-superpowers, verification-before-completion)
- Fix `{PLAN_OR_REQUIREMENTS}` → `{PLAN_REFERENCE}` placeholder mismatch in requesting-code-review
- Remove `@` prefix from file references in test-driven-development (prevents force-loading)
- Remove references to nonexistent skills (frontend-design, mcp-builder) in using-superpowers

## Test plan
- [x] All 5 descriptions start with "Use when..." and contain no workflow summaries
- [x] requesting-code-review placeholder matches reviewer-prompt.md
- [x] No `@` file references remain in test-driven-development

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Refined code review feedback guidance for improved clarity on handling unclear comments.
  * Expanded testing anti-patterns with new three-level integration testing guidance.
  * Introduced mandatory verification rule for test-driven development requiring failing tests first.
  * Updated skill priority recommendations and clarified tool usage requirements across multiple areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->