### PR TITLE
refactor(skills): trim bloat across 8 skills (-452 lines)

### DIFF
--- a/skills/codebase-review/SKILL.md
+++ b/skills/codebase-review/SKILL.md
@@ -11,8 +11,6 @@ Audit an entire codebase (or a specified directory) for code quality issues, pro
 
 **Core principle:** Periodic whole-repo audits catch issues that per-task and per-feature reviews miss — cross-module duplication, accumulated complexity, and style drift.
 
-**Announce at start:** "I'm using the codebase-review skill to audit the codebase."
-
 ## When to Use
 
 - Periodic codebase health checks ("review the codebase", "audit code quality")
@@ -45,32 +43,6 @@ Audit an entire codebase (or a specified directory) for code quality issues, pro
 - **High** — Significant maintenance burden or correctness risk
 - **Medium** — Code smell that makes the codebase harder to work with
 - **Low** — Minor style/convention issue
-
-## The Process
-
-```dot
-digraph codebase_review {
-    "Resolve scope" [shape=box];
-    "Discover review units" [shape=box];
-    "Dispatch parallel reviewers" [shape=box];
-    "Cross-scope reconciliation" [shape=box];
-    "Aggregate & write report" [shape=box];
-    "Present findings" [shape=box];
-    "Triage: complex vs inline" [shape=diamond];
-    "Create GH issues for complex work" [shape=box];
-    "Invoke writing-plans for inline fixes" [shape=doublecircle];
-
-    "Resolve scope" -> "Discover review units";
-    "Discover review units" -> "Dispatch parallel reviewers";
-    "Dispatch parallel reviewers" -> "Cross-scope reconciliation";
-    "Cross-scope reconciliation" -> "Aggregate & write report";
-    "Aggregate & write report" -> "Present findings";
-    "Present findings" -> "Triage: complex vs inline";
-    "Triage: complex vs inline" -> "Create GH issues for complex work" [label="needs own plan"];
-    "Triage: complex vs inline" -> "Invoke writing-plans for inline fixes" [label="inline fixes"];
-    "Create GH issues for complex work" -> "Invoke writing-plans for inline fixes";
-}
-```
 
 ### Phase 1 — Resolve Scope & Discover Review Units
 
@@ -164,19 +136,6 @@ Approach: Parallel scope review (N units) + cross-scope reconciliation
 ### Skipping cross-scope reconciliation
 - **Problem:** Cross-directory DRY violations and naming drift go undetected
 - **Fix:** Always run the reconciliation pass after parallel reviews
-
-## Red Flags
-
-**Never:**
-- Skip the cross-scope reconciliation pass
-- Auto-create GH issues without user confirmation
-- Route complex multi-file refactors through inline fixes
-- Proceed to fixes without writing the report first
-
-**Always:**
-- Let the user decide which complex items become GH issues
-- Write the report before starting any fixes
-- Route inline fixes through writing-plans (not ad-hoc edits)
 
 ## Integration
 

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -13,24 +13,6 @@ When you have multiple unrelated failures (different test files, different subsy
 
 ## When to Use
 
-```dot
-digraph when_to_use {
-    "Multiple failures?" [shape=diamond];
-    "Are they independent?" [shape=diamond];
-    "Single agent investigates all" [shape=box];
-    "One agent per problem domain" [shape=box];
-    "Can they work in parallel?" [shape=diamond];
-    "Sequential agents" [shape=box];
-    "Parallel dispatch" [shape=box];
-
-    "Multiple failures?" -> "Are they independent?" [label="yes"];
-    "Are they independent?" -> "Single agent investigates all" [label="no - related"];
-    "Are they independent?" -> "Can they work in parallel?" [label="yes"];
-    "Can they work in parallel?" -> "Parallel dispatch" [label="yes"];
-    "Can they work in parallel?" -> "Sequential agents" [label="no - shared state"];
-}
-```
-
 **Use when:**
 - 3+ test files failing with different root causes
 - Multiple subsystems broken independently
@@ -155,13 +137,6 @@ Agent 3 → Fix tool-approval-race-conditions.test.ts
 
 **Time saved:** 3 problems solved in parallel vs sequentially
 
-## Key Benefits
-
-1. **Parallelization** - Multiple investigations happen simultaneously
-2. **Focus** - Each agent has narrow scope, less context to track
-3. **Independence** - Agents don't interfere with each other
-4. **Speed** - 3 problems solved in time of 1
-
 ## Verification
 
 After agents return:
@@ -170,21 +145,3 @@ After agents return:
 3. **Run full suite** - Verify all fixes work together
 4. **Spot check** - Agents can make systematic errors
 
-## Native Task Integration
-
-Use Claude Code's native task management to track parallel agent work:
-
-- **Before dispatch:** Call `TaskCreate` for each agent's scope — one task per agent. Parallel tasks have NO `blockedBy` dependencies (they run concurrently).
-- **During execution:** Each agent's task should be marked `in_progress` before dispatch.
-- **After completion:** `TaskUpdate` each task to `completed` as agents return results.
-- **Monitoring:** Call `TaskList` to see which agents have completed and which are still running.
-- **Integration task:** Create a final `TaskCreate` with `blockedBy` referencing all agent tasks — this blocks until all agents finish, then you review and integrate results.
-
-## Real-World Impact
-
-From debugging session (2025-10-03):
-- 6 failures across 3 files
-- 3 agents dispatched in parallel
-- All investigations completed concurrently
-- All fixes integrated successfully
-- Zero conflicts between agent changes

--- a/skills/implementation-review/SKILL.md
+++ b/skills/implementation-review/SKILL.md
@@ -17,31 +17,6 @@ Review the entire feature implementation with fresh eyes, focusing on issues tha
 
 **Not needed for:** Single-task changes, hotfixes, documentation-only PRs.
 
-## The Process
-
-```dot
-digraph process {
-    rankdir=TB;
-    "Get base branch SHA (origin/main or where feature diverged)" [shape=box];
-    "Get HEAD SHA (current commit)" [shape=box];
-    "Verify integration test coverage (Level 1 pass, Level 2 exist, fill gaps)" [shape=box];
-    "Dispatch reviewer subagent with ./reviewer-prompt.md" [shape=box];
-    "Reviewer finds issues?" [shape=diamond];
-    "Fix issues (dispatch implementer or fix directly)" [shape=box];
-    "Re-run implementation review" [shape=box];
-    "Proceed to superpowers:ship" [shape=box style=filled fillcolor=lightgreen];
-
-    "Get base branch SHA (origin/main or where feature diverged)" -> "Get HEAD SHA (current commit)";
-    "Get HEAD SHA (current commit)" -> "Verify integration test coverage (Level 1 pass, Level 2 exist, fill gaps)";
-    "Verify integration test coverage (Level 1 pass, Level 2 exist, fill gaps)" -> "Dispatch reviewer subagent with ./reviewer-prompt.md";
-    "Dispatch reviewer subagent with ./reviewer-prompt.md" -> "Reviewer finds issues?";
-    "Reviewer finds issues?" -> "Fix issues (dispatch implementer or fix directly)" [label="yes"];
-    "Fix issues (dispatch implementer or fix directly)" -> "Re-run implementation review" [label="re-review"];
-    "Re-run implementation review" -> "Reviewer finds issues?";
-    "Reviewer finds issues?" -> "Proceed to superpowers:ship" [label="no"];
-}
-```
-
 ## Integration Test Verification (Before Review)
 
 By this point, integration tests should already exist from the implementation phase:
@@ -92,18 +67,6 @@ Then dispatch using `./reviewer-prompt.md` template with:
 | Documentation gaps | Feature supported in one module but not another, undocumented | Per-task reviewer sees one side |
 | Unclear/inconsistent errors | Multiple modules throw same generic message | Each reviewer sees one throw site |
 | Missing boundary tests | Components interact but no Level 2 boundary test at the seam | Per-task reviewer sees one side |
-
-## Red Flags
-
-**Never:**
-- Use per-task SHA range (defeats the purpose)
-- Skip this because per-task reviews passed (that's exactly when cross-task issues hide)
-- Treat this as optional for multi-task features
-
-**If reviewer finds issues:**
-- Fix them before proceeding to ship
-- Re-run the review after fixes
-- Don't skip re-review
 
 ## Post-Review: Plan Doc Updates
 

--- a/skills/plan-review/SKILL.md
+++ b/skills/plan-review/SKILL.md
@@ -11,8 +11,6 @@ Dispatch an Opus subagent to review a written plan for internal consistency and 
 
 **Core principle:** Plans are hypotheses about how to build something. Validate the hypothesis before running the experiment.
 
-**Announce at start:** "I'm using the plan-review skill to validate this plan before execution."
-
 ## When to Use
 
 - After writing-plans produces a plan document
@@ -20,27 +18,6 @@ Dispatch an Opus subagent to review a written plan for internal consistency and 
 - When resuming work on a plan that's been idle (context may have drifted)
 
 **Not needed for:** Single-task plans, hotfix plans, plans with no design doc reference.
-
-## The Process
-
-```dot
-digraph process {
-    rankdir=TB;
-    "Locate plan file and design doc" [shape=box];
-    "Dispatch Opus reviewer with ./reviewer-prompt.md" [shape=box];
-    "Issues found?" [shape=diamond];
-    "Fix plan (not code)" [shape=box];
-    "Re-run plan review" [shape=box];
-    "Proceed to execution" [shape=box style=filled fillcolor=lightgreen];
-
-    "Locate plan file and design doc" -> "Dispatch Opus reviewer with ./reviewer-prompt.md";
-    "Dispatch Opus reviewer with ./reviewer-prompt.md" -> "Issues found?";
-    "Issues found?" -> "Fix plan (not code)" [label="yes"];
-    "Fix plan (not code)" -> "Re-run plan review" [label="re-review"];
-    "Re-run plan review" -> "Issues found?";
-    "Issues found?" -> "Proceed to execution" [label="no"];
-}
-```
 
 ## How to Dispatch
 
@@ -70,18 +47,6 @@ Then dispatch using `./reviewer-prompt.md` template with:
 | Tech stack contradictions | Plan header says SQLite, Task 3 uses PostgreSQL syntax | Header written first, tasks written later with different assumptions |
 | Implied context | Task says "modify the auth handler" without specifying file | Planner has conversation context that won't exist during execution |
 | Missing mandatory fields | Task has no verification command or measurable done criteria | Planner assumes executor will figure it out |
-
-## Red Flags
-
-**Never:**
-- Skip this because "the plan looks fine" (that's what the planner always thinks)
-- Fix issues by editing code (there is no code yet — fix the plan)
-- Let minor issues slide (they compound during implementation)
-
-**If reviewer finds issues:**
-- Fix the plan document
-- Re-run review after fixes
-- Don't skip re-review
 
 ## Integration
 

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -89,17 +89,4 @@ You: [Fix progress indicators]
 - Review before merge
 - Review when stuck
 
-## Red Flags
-
-**Never:**
-- Skip review because "it's simple"
-- Ignore Critical issues
-- Proceed with unfixed Important issues
-- Argue with valid technical feedback
-
-**If reviewer wrong:**
-- Push back with technical reasoning
-- Show code/tests that prove it works
-- Request clarification
-
 See template at: requesting-code-review/code-reviewer.md

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -11,71 +11,15 @@ Execute plan by dispatching fresh subagent per task, with two-stage review after
 
 ## When to Use
 
-```dot
-digraph when_to_use {
-    "Have implementation plan?" [shape=diamond];
-    "Tasks mostly independent?" [shape=diamond];
-    "subagent-driven-development" [shape=box];
-    "Manual execution or brainstorm first" [shape=box];
-
-    "Have implementation plan?" -> "Tasks mostly independent?" [label="yes"];
-    "Have implementation plan?" -> "Manual execution or brainstorm first" [label="no"];
-    "Tasks mostly independent?" -> "subagent-driven-development" [label="yes"];
-    "Tasks mostly independent?" -> "Manual execution or brainstorm first" [label="no - tightly coupled"];
-}
-```
+- Have an implementation plan with mostly independent tasks
+- Tasks can be dispatched one at a time to fresh subagents
+- Don't use for tightly coupled tasks or when no plan exists
 
 ## The Process
 
-```dot
-digraph process {
-    rankdir=TB;
+**Per task:** Dispatch implementer → spec compliance review → code quality review → mark complete
 
-    subgraph cluster_per_task {
-        label="Per Task";
-        "Dispatch implementer subagent (./implementer-prompt.md)" [shape=box];
-        "Implementer subagent asks questions?" [shape=diamond];
-        "Answer questions, provide context" [shape=box];
-        "Implementer subagent implements, tests, commits, self-reviews" [shape=box];
-        "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" [shape=box];
-        "Spec reviewer subagent confirms code matches spec?" [shape=diamond];
-        "Implementer subagent fixes spec gaps" [shape=box];
-        "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [shape=box];
-        "Code quality reviewer subagent approves?" [shape=diamond];
-        "Implementer subagent fixes quality issues" [shape=box];
-        "TaskUpdate: mark task completed" [shape=box];
-    }
-
-    "Read plan, extract all tasks with full text, note context, TaskCreate for each\n(Task 0 is first: broad integration tests)" [shape=box];
-    "More tasks remain?" [shape=diamond];
-    "Verify Task 0 broad integration tests pass (GREEN)" [shape=box];
-    "Auto-dispatch implementation reviewer (skills/implementation-review/reviewer-prompt.md)" [shape=box];
-    "Auto-invoke superpowers:ship" [shape=box style=filled fillcolor=lightgreen];
-
-    "Read plan, extract all tasks with full text, note context, TaskCreate for each\n(Task 0 is first: broad integration tests)" -> "TaskList to find next pending task";
-    "TaskList to find next pending task" -> "Dispatch implementer subagent (./implementer-prompt.md)";
-    "Dispatch implementer subagent (./implementer-prompt.md)" -> "Implementer subagent asks questions?";
-    "Implementer subagent asks questions?" -> "Answer questions, provide context" [label="yes"];
-    "Answer questions, provide context" -> "Dispatch implementer subagent (./implementer-prompt.md)";
-    "Implementer subagent asks questions?" -> "Implementer subagent implements, tests, commits, self-reviews" [label="no"];
-    "Implementer subagent implements, tests, commits, self-reviews" -> "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)";
-    "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" -> "Spec reviewer subagent confirms code matches spec?";
-    "Spec reviewer subagent confirms code matches spec?" -> "Implementer subagent fixes spec gaps" [label="no"];
-    "Implementer subagent fixes spec gaps" -> "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" [label="re-review"];
-    "Spec reviewer subagent confirms code matches spec?" -> "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [label="yes"];
-    "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" -> "Code quality reviewer subagent approves?";
-    "Code quality reviewer subagent approves?" -> "Implementer subagent fixes quality issues" [label="no"];
-    "Implementer subagent fixes quality issues" -> "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [label="re-review"];
-    "Code quality reviewer subagent approves?" -> "TaskUpdate: mark task completed" [label="yes"];
-    "TaskUpdate: mark task completed" -> "More tasks remain?";
-    "More tasks remain?" -> "TaskList to find next pending task" [label="yes"];
-    "Write completion report to plan doc" [shape=box];
-    "More tasks remain?" -> "Write completion report to plan doc" [label="no"];
-    "Write completion report to plan doc" -> "Verify Task 0 broad integration tests pass (GREEN)";
-    "Verify Task 0 broad integration tests pass (GREEN)" -> "Auto-dispatch implementation reviewer (skills/implementation-review/reviewer-prompt.md)";
-    "Auto-dispatch implementation reviewer (skills/implementation-review/reviewer-prompt.md)" -> "Auto-invoke superpowers:ship";
-}
-```
+**After all tasks:** Write completion report → verify Task 0 integration tests pass → implementation review → ship
 
 ## Prompt Templates
 
@@ -179,33 +123,6 @@ PR created! Waiting for CodeRabbit review. Use /merge-pr after review.
 
 **Integration test levels:** Task 0 provides Level 1 (broad acceptance tests, written first). Each implementer writes Level 2 (boundary tests at cross-task seams, during TDD). Implementation-review provides Level 3 (coverage verification). See test-driven-development/testing-anti-patterns.md Anti-Pattern 5 for details.
 
-## Advantages
-
-**vs. Manual execution:**
-- Subagents follow TDD naturally
-- Fresh context per task (no confusion)
-- Parallel-safe (subagents don't interfere)
-- Subagent can ask questions (before AND during work)
-
-**Efficiency gains:**
-- No file reading overhead (controller provides full text)
-- Controller curates exactly what context is needed
-- Subagent gets complete information upfront
-- Questions surfaced before work begins (not after)
-
-**Quality gates:**
-- Self-review catches issues before handoff
-- Two-stage review: spec compliance, then code quality
-- Review loops ensure fixes actually work
-- Spec compliance prevents over/under-building
-- Code quality ensures implementation is well-built
-
-**Cost:**
-- More subagent invocations (implementer + 2 reviewers per task)
-- Controller does more prep work (extracting all tasks upfront)
-- Review loops add iterations
-- But catches issues early (cheaper than debugging later)
-
 ## Deviation Rules
 
 When reality diverges from the plan, follow these rules in order:
@@ -276,36 +193,14 @@ Use the Agent tool (general-purpose, model: "opus") with the prompt template fro
 - Write handoff notes to next phase (if multi-phase plan)
 - Update phase status to `Complete (YYYY-MM-DD)`
 
-## Red Flags
+## Key Constraints
 
-**Never:**
-- Start implementation on main/master branch without explicit user consent
-- Skip reviews (spec compliance OR code quality)
-- Proceed with unfixed issues
-- Dispatch multiple implementation subagents in parallel (conflicts)
-- Make subagent read plan file (provide full text instead)
-- Skip scene-setting context (subagent needs to understand where task fits)
-- Ignore subagent questions (answer before letting them proceed)
-- Accept "close enough" on spec compliance (spec reviewer found issues = not done)
-- Skip review loops (reviewer found issues = implementer fixes = review again)
-- Let implementer self-review replace actual review (both are needed)
-- **Start code quality review before spec compliance is ✅** (wrong order)
-- Move to next task while either review has open issues
-
-**If subagent asks questions:**
-- Answer clearly and completely
-- Provide additional context if needed
-- Don't rush them into implementation
-
-**If reviewer finds issues:**
-- Implementer (same subagent) fixes them
-- Reviewer reviews again
-- Repeat until approved
-- Don't skip the re-review
-
-**If subagent fails task:**
-- Dispatch fix subagent with specific instructions
-- Don't try to fix manually (context pollution)
+| Constraint | Why it matters |
+|-----------|---------------|
+| One implementer at a time | Parallel implementers cause git conflicts and file overwrites |
+| Provide full task text, don't make subagent read the plan file | Reading wastes subagent context on irrelevant tasks; controller curates what's needed |
+| Spec compliance before code quality review | Code quality review is wasted effort if the implementation doesn't match spec |
+| Answer subagent questions before they proceed | Subagents working on assumptions produce work that needs to be redone |
 
 ## Integration
 

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -5,135 +5,57 @@ description: Use when starting feature work that needs isolation from current wo
 
 # Using Git Worktrees
 
-## Overview
-
 Git worktrees create isolated workspaces sharing the same repository, allowing work on multiple branches simultaneously without switching.
 
 **Core principle:** Systematic directory selection + safety verification = reliable isolation.
 
-**Announce at start:** "I'm using the using-git-worktrees skill to set up an isolated workspace."
+## Workflow
 
-## Directory Selection Process
+### 1. Find or Create Worktree Directory
 
-Follow this priority order:
+Follow this priority — never assume a location:
 
-### 1. Check Existing Directories
+1. **Check existing directories:** Look for `.worktrees/` then `worktrees/` (`.worktrees/` wins if both exist)
+2. **Check CLAUDE.md** for a worktree directory preference
+3. **Ask the user** which location to use
 
-```bash
-# Check in priority order
-ls -d .worktrees 2>/dev/null     # Preferred (hidden)
-ls -d worktrees 2>/dev/null      # Alternative
-```
+### 2. Verify .gitignore (Project-Local Only)
 
-**If found:** Use that directory. If both exist, `.worktrees` wins.
-
-### 2. Check CLAUDE.md
+Before creating a worktree in a project-local directory, verify it's git-ignored:
 
 ```bash
-grep -i "worktree.*director" CLAUDE.md 2>/dev/null
+git check-ignore -q .worktrees 2>/dev/null
 ```
 
-**If preference specified:** Use it without asking.
+If not ignored: add to `.gitignore` and commit before proceeding. Unignored worktree directories get tracked and pollute git status — a messy problem to clean up after the fact.
 
-### 3. Ask User
+Global directories (e.g. `~/.config/superpowers/worktrees/`) skip this check.
 
-If no directory exists and no CLAUDE.md preference:
-
-```
-No worktree directory found. Where should I create worktrees?
-
-1. .worktrees/ (project-local, hidden)
-2. ~/.config/superpowers/worktrees/<project-name>/ (global location)
-
-Which would you prefer?
-```
-
-## Safety Verification
-
-### For Project-Local Directories (.worktrees or worktrees)
-
-**MUST verify directory is ignored before creating worktree:**
+### 3. Create Worktree
 
 ```bash
-# Check if directory is ignored (respects local, global, and system gitignore)
-git check-ignore -q .worktrees 2>/dev/null || git check-ignore -q worktrees 2>/dev/null
+git worktree add <path>/<branch-name> -b <branch-name>
 ```
 
-**If NOT ignored:**
+Use the absolute path for all subsequent commands — `cd` in Claude Code's bash tool does not persist across calls.
 
-Fix broken things immediately:
-1. Add appropriate line to .gitignore
-2. Commit the change
-3. Proceed with worktree creation
+### 4. Run Project Setup
 
-**Why critical:** Prevents accidentally committing worktree contents to repository.
+Auto-detect from project files:
 
-### For Global Directory (~/.config/superpowers/worktrees)
+| File | Command |
+|------|---------|
+| `package.json` | `npm install` |
+| `requirements.txt` | `pip install -r requirements.txt` |
+| `pyproject.toml` | `poetry install` or `pip install -e .` |
+| `Cargo.toml` | `cargo build` |
+| `go.mod` | `go mod download` |
 
-No .gitignore verification needed - outside project entirely.
+### 5. Verify Clean Baseline
 
-## Creation Steps
+Run the project's test suite. If tests fail, report failures and ask whether to proceed or investigate — don't silently continue, because you won't be able to tell later whether failures are pre-existing or caused by your changes.
 
-### 1. Detect Project Name
-
-```bash
-project=$(basename "$(git rev-parse --show-toplevel)")
-```
-
-### 2. Create Worktree
-
-```bash
-# Determine full path
-case $LOCATION in
-  .worktrees|worktrees)
-    path="$LOCATION/$BRANCH_NAME"
-    ;;
-  ~/.config/superpowers/worktrees/*)
-    path="~/.config/superpowers/worktrees/$project/$BRANCH_NAME"
-    ;;
-esac
-
-# Create worktree with new branch
-git worktree add "$path" -b "$BRANCH_NAME"
-cd "$path"
-```
-
-### 3. Run Project Setup
-
-Auto-detect and run appropriate setup:
-
-```bash
-# Node.js
-if [ -f package.json ]; then npm install; fi
-
-# Rust
-if [ -f Cargo.toml ]; then cargo build; fi
-
-# Python
-if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-if [ -f pyproject.toml ]; then poetry install; fi
-
-# Go
-if [ -f go.mod ]; then go mod download; fi
-```
-
-### 4. Verify Clean Baseline
-
-Run tests to ensure worktree starts clean:
-
-```bash
-# Examples - use project-appropriate command
-npm test
-cargo test
-pytest
-go test ./...
-```
-
-**If tests fail:** Report failures, ask whether to proceed or investigate.
-
-**If tests pass:** Report ready.
-
-### 5. Report Location
+### 6. Report Ready
 
 ```
 Worktree ready at <full-path>
@@ -153,66 +75,12 @@ Ready to implement <feature-name>
 | Tests fail during baseline | Report failures + ask |
 | No package.json/Cargo.toml | Skip dependency install |
 
-## Common Mistakes
-
-### Skipping ignore verification
-
-- **Problem:** Worktree contents get tracked, pollute git status
-- **Fix:** Always use `git check-ignore` before creating project-local worktree
-
-### Assuming directory location
-
-- **Problem:** Creates inconsistency, violates project conventions
-- **Fix:** Follow priority: existing > CLAUDE.md > ask
-
-### Proceeding with failing tests
-
-- **Problem:** Can't distinguish new bugs from pre-existing issues
-- **Fix:** Report failures, get explicit permission to proceed
-
-### Hardcoding setup commands
-
-- **Problem:** Breaks on projects using different tools
-- **Fix:** Auto-detect from project files (package.json, etc.)
-
-## Example Workflow
-
-```
-You: I'm using the using-git-worktrees skill to set up an isolated workspace.
-
-[Check .worktrees/ - exists]
-[Verify ignored - git check-ignore confirms .worktrees/ is ignored]
-[Create worktree: git worktree add .worktrees/auth -b feature/auth]
-[Run npm install]
-[Run npm test - 47 passing]
-
-Worktree ready at /home/user/myproject/.worktrees/auth
-Tests passing (47 tests, 0 failures)
-Ready to implement auth feature
-```
-
-## Red Flags
-
-**Never:**
-- Create worktree without verifying it's ignored (project-local)
-- Skip baseline test verification
-- Proceed with failing tests without asking
-- Assume directory location when ambiguous
-- Skip CLAUDE.md check
-
-**Always:**
-- Follow directory priority: existing > CLAUDE.md > ask
-- Verify directory is ignored for project-local
-- Auto-detect and run project setup
-- Verify clean test baseline
-
 ## Integration
 
 **Called by:**
-- **brainstorming** - REQUIRED after design approval, before implementation begins
-- **subagent-driven-development** - REQUIRED before executing any tasks
-- Any skill needing isolated workspace
+- **brainstorming** — after design approval, before implementation begins
+- **subagent-driven-development** — before executing any tasks
 
 **Pairs with:**
-- **ship** - Commits, pushes, creates PR after work complete
-- **merge-pr** - Addresses review feedback, merges PR, cleans up worktree and branch
+- **ship** — commits, pushes, creates PR after work complete
+- **merge-pr** — addresses review feedback, merges PR, cleans up worktree and branch

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -11,8 +11,6 @@ Write comprehensive implementation plans assuming the engineer has zero context 
 
 Assume they are a skilled developer, but know almost nothing about our toolset or problem domain. Assume they don't know good test design very well.
 
-**Announce at start:** "I'm using the writing-plans skill to create the implementation plan."
-
 **Context:** This should be run in a dedicated worktree (created by brainstorming skill after design approval).
 
 **Save plans to:** `docs/plans/YYYY-MM-DD-<topic>/plan-<topic>.md` (inside the topic folder created by brainstorming)


### PR DESCRIPTION
## Summary
- **using-git-worktrees**: full rewrite 772w to 427w, consolidated workflow, added cd caveat
- **subagent-driven-development**: removed 2 dot graphs, Advantages section, replaced Red Flags with Key Constraints table (1773w to 1261w)
- **dispatching-parallel-agents**: removed dot graph, Key Benefits, Native Task Integration (975w to 711w)
- **codebase-review**: removed Announce, dot graph, Red Flags (1085w to 946w)
- **implementation-review**: removed dot graph, Red Flags (920w to 754w)
- **plan-review**: removed Announce, dot graph, Red Flags (593w to 488w)
- **requesting-code-review**: removed Red Flags (321w)
- **writing-plans**: removed Announce line

Red Flags kept in discipline skills (TDD, verification, debugging) where rationalization resistance is load-bearing.

## Test plan
- [ ] Verify each skill triggers correctly
- [ ] Spot-check that removed content was genuinely redundant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified skill module documentation by removing process diagrams and advisory sections for improved clarity.
  * Consolidated guidance content across code-review, plan-review, dispatching, and implementation-review modules.
  * Restructured workflows in using-git-worktrees and subagent-driven-development to focus on essential procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->