### PR TITLE
refactor(skills): trim subagent-driven-development from 1261w to 646w

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -32,7 +32,7 @@ Execute plan by dispatching fresh subagent per task, with two-stage review after
 
 ## Example Workflow
 
-```
+```text
 [Read plan once, extract all tasks, create TaskCreate for each]
 
 Task 0: Broad integration tests


### PR DESCRIPTION
## Summary
- Trimmed subagent-driven-development SKILL.md from 1,261 words to 646 words (-49%), well under the 1,000w hard cap
- Compressed example workflow from 90 lines to 27 lines while preserving all key patterns (question asking, spec rejection cycles, code quality fix cycles, implementation review, ship)
- Converted verbose prose sections (plan doc updates, implementation review, integration) to compact tables and one-liners

## Test plan
- [ ] Verify SKILL.md loads correctly as a skill
- [ ] Verify all essential behaviors preserved: two-stage review, deviation rules, plan doc updates, implementation review flow, integration workflow
- [ ] Confirm prompt template references still point to correct files

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote workflows into concise, template-driven sequences with clear progression signals (dispatch → review → complete).
  * Replaced long examples with action-oriented snippets, inline traces, and compact fix-and-verify lines.
  * Standardized prompts, reviews, constraints, and plan updates into short, tabular/prescriptive formats for easier reference and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->