### PR TITLE
refactor(skills): trim merge-pr, fix worktree path derivation

### DIFF
--- a/skills/merge-pr/SKILL.md
+++ b/skills/merge-pr/SKILL.md
@@ -15,7 +15,7 @@ Address review feedback, comment on the PR, merge with squash, and clean up.
 
 ### Step 1: Setup
 
-Identify the PR from argument, current branch, or `gh pr list --author @me --state open`. Store PR number, branch name, and URL.
+Identify the PR from argument or current branch. If neither works, run `gh pr list --author @me --state open` and ask the user to pick one (never auto-select when multiple candidates exist). Store PR number, branch name, and URL.
 
 Detect environment:
 - `DEFAULT_BRANCH` from `refs/remotes/origin/HEAD` (fallback: main/master)
@@ -67,9 +67,9 @@ Never use `--delete-branch` — branch cleanup is handled in Step 6.
 
 **Worktree — run each sub-step as a SEPARATE Bash tool call.** Never chain with `&&` — CWD changes don't persist if a later chained command fails, bricking the shell.
 
-Derive `WORKTREE_PATH` if not already captured:
+Derive `WORKTREE_PATH` if not already captured (exact branch match — grep substring would collide on similar names like `feature` vs `feature-2`):
 ```bash
-git worktree list --porcelain | grep -B2 "branch refs/heads/$BRANCH_NAME" | head -1 | sed 's/^worktree //'
+git worktree list --porcelain | awk -v b="refs/heads/$BRANCH_NAME" '$1=="worktree"{wt=$2} $1=="branch" && $2==b{print wt; exit}'
 ```
 
 1. `git worktree remove "$WORKTREE_PATH"` (retry with `--force` if untracked files)


### PR DESCRIPTION
## Summary
- Trim merge-pr skill from 1,201w to 653w (-46%) by removing code blocks the agent already knows (gh CLI, test detection, commit/comment templates), merging Safety into Pitfalls, and fixing convention violations
- Fix description to trigger-condition-only format, replace vendor-specific "coderabbit reviewed" trigger with tool-agnostic "review feedback ready"
- Derive WORKTREE_PATH from `git worktree list --porcelain` by matching branch name — works regardless of CWD, handles session restarts and cross-session worktrees (closes #32)

## Test plan
- [ ] Verify `/merge-pr` triggers correctly on natural language variants
- [ ] Verify worktree path derivation works from inside worktree and from main repo
- [ ] Verify `--skip-fixes` skips entire Step 3
- [ ] Verify assessment categories and receiving-code-review reference are clear

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Reorganized and updated Merge PR workflow documentation with simplified step structure and clearer guidance
* Enhanced environment-aware setup instructions including branch detection and PR checkout procedures
* Improved feedback assessment process with refined categories and clarified evaluation expectations
* Refined merge and cleanup procedures with detailed steps and updated safety cautions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->