### PR TITLE
chore(plugin): bump version to 4.4.0 to refresh skill names

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "4.3.1",
+      "version": "4.4.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -30,7 +30,7 @@
     {
       "name": "claude-caliper-workflow",
       "description": "End-to-end development workflow: build → draft-plan → orchestrate → review → ship → merge",
-      "version": "4.3.1",
+      "version": "4.4.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -50,7 +50,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit and skill evaluation",
-      "version": "4.3.1",
+      "version": "4.4.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",


### PR DESCRIPTION
## Summary
- Bumps all three plugin variants from 4.3.1 → 4.4.0
- Triggers plugin cache refresh so `/plugin update claude-caliper` picks up the skill renames from #66 (brainstorming→build, writing-plans→draft-plan, orchestrating→orchestrate)

## Test plan
- [ ] Merge and run `/plugin update claude-caliper` in Claude Code
- [ ] Verify `brainstorming` no longer appears in `/` list, replaced by `build`, `draft-plan`, `orchestrate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updates for three plugins: claude-caliper, claude-caliper-workflow, and claude-caliper-tooling have been bumped to version 4.4.0 (from 4.3.1). These are maintenance releases with no changes to features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->