### PR TITLE
chore: reset plugin version to 1.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "4.4.0",
+      "version": "1.0.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -30,7 +30,7 @@
     {
       "name": "claude-caliper-workflow",
       "description": "End-to-end development workflow: build → draft-plan → orchestrate → review → ship → merge",
-      "version": "4.4.0",
+      "version": "1.0.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -50,7 +50,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit and skill evaluation",
-      "version": "4.4.0",
+      "version": "1.0.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",


### PR DESCRIPTION
## Summary
- Reset all three plugin versions from 4.4.0 to 1.0.0 to reflect fresh repo start

## Test plan
- No tests applicable (config-only change)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>