### PR TITLE
refactor: rename phase executor to phase dispatcher

### DIFF
--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -5,18 +5,31 @@ description: Use when executing implementation plans with independent tasks in t
 
 # Orchestrate
 
-Execute plan phase by phase: dispatch a fresh phase executor subagent per phase, then dispatch implementation-review from the orchestrate context, report phase completion, and advance. After all phases, auto-invoke ship.
+Execute plan phase by phase: dispatch a fresh phase dispatcher subagent per phase, then dispatch implementation-review from the orchestrate context, report phase completion, and advance. After all phases, auto-invoke ship.
 
-**Core principle:** Phase executor handles implementation. Orchestrate context handles review, reporting, and phase advancement.
+**Core principle:** Every level is a dispatcher. Orchestrate dispatches phase dispatchers. Phase dispatchers dispatch implementers and reviewers. No level writes application code itself — only the implementer subagent touches code.
 
 ## When to Use
 
 - Have an implementation plan with mostly independent tasks
 - Don't use for tightly coupled tasks or when no plan exists
 
+## Subagent Hierarchy
+
+```text
+Orchestrate (you)           — 1 per plan
+├── Phase Dispatcher        — 1 per phase (dispatches implementers + reviewers, never writes code)
+│   ├── Implementer         — 1 per task (fresh context, writes code via TDD)
+│   ├── Spec Reviewer       — 1 per task (evaluates code cold)
+│   └── Code Quality Rev.   — 1 per task (evaluates code cold)
+└── Implementation Review   — 1 per phase (cross-task holistic, dispatched by you)
+```
+
+Why separate subagents per task: each implementer starts with fresh context, preventing quality degradation as tasks accumulate. Each reviewer evaluates code without having seen the implementation rationale. These isolation properties break when a single agent implements multiple tasks inline.
+
 ## The Process
 
-**Per phase:** Record BASE_SHA → dispatch phase executor (all tasks + per-task reviews + completion report) → dispatch implementation-review → emit phase summary → fix issues → write handoff notes → advance
+**Per phase:** Record BASE_SHA → dispatch phase dispatcher (dispatches per-task implementers + reviewers, writes completion report) → dispatch implementation-review → emit phase summary → fix issues → write handoff notes → advance
 
 **After all phases:** Update plan status → auto-invoke ship.
 
@@ -24,10 +37,10 @@ Execute plan phase by phase: dispatch a fresh phase executor subagent per phase,
 
 | Template | Purpose |
 |----------|---------|
-| `./phase-executor-prompt.md` | Dispatch phase executor subagent (sequential tasks + per-task reviews + completion report) |
-| `./implementer-prompt.md` | Dispatch individual task implementer (used inside phase executor and for post-review fix work) |
-| `./spec-reviewer-prompt.md` | Spec compliance reviewer (used inside phase executor) |
-| `./code-quality-reviewer-prompt.md` | Code quality reviewer (used inside phase executor) |
+| `./phase-dispatcher-prompt.md` | Dispatch phase dispatcher subagent (dispatches per-task implementers + reviewers, writes completion report) |
+| `./implementer-prompt.md` | Dispatch individual task implementer (used inside phase dispatcher and for post-review fix work) |
+| `./spec-reviewer-prompt.md` | Spec compliance reviewer (used inside phase dispatcher) |
+| `./code-quality-reviewer-prompt.md` | Code quality reviewer (used inside phase dispatcher) |
 | `skills/implementation-review/reviewer-prompt.md` | Holistic cross-task reviewer (dispatched from orchestrate context after each phase) |
 
 ## Example Workflow
@@ -36,7 +49,7 @@ Execute plan phase by phase: dispatch a fresh phase executor subagent per phase,
 [Read plan, identify phases]
 
 Phase 1 BASE_SHA = $(git rev-parse HEAD)
-[Dispatch phase executor: Phase 1]
+[Dispatch phase dispatcher: Phase 1]
   Internal: Task 0 (integration tests) → Task 1 (hook install) → Task 2 (recovery modes)
   Each task: implementer → spec review → code review → mark complete
   Writes completion report. Returns summary + HEAD SHA.
@@ -48,7 +61,7 @@ Phase 1 BASE_SHA = $(git rev-parse HEAD)
 Phase 1 summary: 3 tasks complete. Review: 2 issues, both fixed.
 [Write handoff notes into plan doc]
 
-[Dispatch phase executor: Phase 2]
+[Dispatch phase dispatcher: Phase 2]
   Internal: Task 3 → Task 4
   Writes completion report. Returns.
 
@@ -65,12 +78,12 @@ Phase 2 summary: 2 tasks complete. Review: 0 issues.
 
 For each phase:
 
-1. `PHASE_BASE_SHA=$(git rev-parse HEAD)` — before dispatching executor
-2. Dispatch phase executor (`./phase-executor-prompt.md`) with:
+1. `PHASE_BASE_SHA=$(git rev-parse HEAD)` — before dispatching
+2. Dispatch phase dispatcher (`./phase-dispatcher-prompt.md`) with:
    - Phase number, name, full task text for this phase
    - PHASE_BASE_SHA
    - PHASE_CONTEXT from prior phase's handoff notes (empty for Phase 1)
-3. After executor returns: dispatch implementation-review (`skills/implementation-review/reviewer-prompt.md`)
+3. After dispatcher returns: dispatch implementation-review (`skills/implementation-review/reviewer-prompt.md`)
    - BASE_SHA = PHASE_BASE_SHA, HEAD_SHA = `git rev-parse HEAD`
    - PHASE_CONTEXT = what downstream phases expect (from plan); empty for final/single phase
 4. Triage findings through deviation rules — dispatch implementer for Rule 1-3; Rule 4 → write BLOCKED to plan doc and terminate (see Rule 4 Handling)
@@ -129,7 +142,7 @@ Under 5 issues: orchestrator verifies fixes and proceeds.
 
 ## Rule 4 Handling
 
-When a phase executor reports a Rule 4 violation, orchestrate cannot ask the user (it runs as a subagent dispatched by draft-plan). Instead:
+When a phase dispatcher reports a Rule 4 violation, orchestrate cannot ask the user (it runs as a subagent dispatched by draft-plan). Instead:
 
 1. Update plan frontmatter:
 
@@ -163,8 +176,8 @@ The user sees the plan doc in a clean BLOCKED state and can resolve the conflict
 | When | Update |
 |------|--------|
 | First task starts | Frontmatter: `status: In Development` |
-| Task completes (inside executor) | `- [ ] Task N` → `- [x] Task N` |
-| Phase executor returns | Phase completion report written to plan doc by executor |
+| Task completes (inside dispatcher) | `- [ ] Task N` → `- [x] Task N` |
+| Phase dispatcher returns | Phase completion report written to plan doc by dispatcher |
 | Review fixes applied | Orchestrate context appends `### Implementation Review Changes` to completion report |
 | Phase review passes | Phase status: `Complete (YYYY-MM-DD)` |
 | All phases done | Frontmatter: `status: Complete` |
@@ -174,7 +187,7 @@ The user sees the plan doc in a clean BLOCKED state and can resolve the conflict
 
 | Constraint | Why |
 |------------|-----|
-| Record BASE_SHA before executor | Implementation-review needs the exact phase start SHA |
+| Record BASE_SHA before dispatcher | Implementation-review needs the exact phase start SHA |
 | Dispatch implementation-review from orchestrate context | Phase completion and any issues must be visible before advancing — this prevents bugs from compounding into the next phase |
 | Fix review issues before next phase | Phase N bugs compound into Phase N+1 complexity |
 | Escalate Rule 4 immediately | Architectural changes need user input, not guessing |

--- a/skills/orchestrate/phase-dispatcher-prompt.md
+++ b/skills/orchestrate/phase-dispatcher-prompt.md
@@ -1,15 +1,22 @@
-# Phase Executor Prompt Template
+# Phase Dispatcher Prompt Template
 
-Use this template when dispatching a phase executor subagent. Substitute all {VARIABLES} before dispatching. The executor handles all tasks in one phase sequentially — per-task reviews included. Implementation Review (cross-task holistic) is dispatched by the orchestrate context after you return — do not run it yourself.
+Use this template when dispatching a phase dispatcher subagent. Substitute all {VARIABLES} before dispatching. The dispatcher handles all tasks in one phase sequentially — dispatching implementers and reviewers per task. Implementation Review (cross-task holistic) is dispatched by the orchestrate context after you return — do not run it yourself.
 
 ```text
 Task tool (general-purpose):
   model: "sonnet"
   mode: "bypassPermissions"
-  description: "Execute Phase {PHASE_NUMBER}: {PHASE_NAME}"
+  description: "Dispatch Phase {PHASE_NUMBER}: {PHASE_NAME}"
   prompt: |
-    You are a phase executor. Your job: implement all tasks for Phase {PHASE_NUMBER}
-    using TDD, pass per-task reviews, and write the completion report.
+    You are a phase dispatcher, not an implementer. You never write
+    application code, tests, or implementation directly. Your only jobs are:
+    dispatching subagents, reading their results, updating the plan doc, and writing
+    the completion report.
+
+    Why: each implementer subagent starts with fresh context, preventing quality
+    degradation as tasks accumulate. Each reviewer subagent evaluates code cold,
+    without having seen the implementation rationale. These isolation properties
+    break if you implement or review inline.
 
     Implementation Review (cross-task holistic) will be dispatched by the orchestrate
     context after you finish — do not run it yourself.
@@ -23,7 +30,7 @@ Task tool (general-purpose):
 
     {TASK_LIST}
 
-    [Paste full text of each task in this phase — do not make executor read the file]
+    [Paste full text of each task in this phase — do not make dispatcher read the file]
 
     ## Prior Phase Context
 
@@ -34,35 +41,36 @@ Task tool (general-purpose):
 
     ## Your Process
 
-    Work through tasks **sequentially** — parallel writes cause git conflicts.
+    Work through tasks **sequentially** — parallel dispatches cause git conflicts.
 
     For each task:
     1. Dispatch implementer subagent (see `./implementer-prompt.md`)
+       - Include in the implementer prompt: if this task consumes output from a prior
+         task (imports a module, reads config, calls an API created earlier), write a
+         boundary integration test using real components — not mocks
     2. After implementer returns: dispatch spec compliance reviewer
        (`./spec-reviewer-prompt.md`)
-       - Issues found → dispatch implementer fix → re-review spec
+       - Issues found → dispatch new implementer to fix → re-review spec
     3. After spec passes: dispatch code quality reviewer
        (`./code-quality-reviewer-prompt.md`)
-       - Issues found → dispatch implementer fix → re-review quality
+       - Issues found → dispatch new implementer to fix → re-review quality
     4. Re-Review Gate: if reviewer found >5 issues, dispatch fresh same-scope reviewer
        after all fixes are applied
     5. Update plan doc: `- [ ] Task N` → `- [x] Task N`
 
-    When a task consumes output from a prior task (imports a module, reads config, calls
-    an API created earlier), write a boundary integration test using real components — not
-    mocks.
-
     ## Deviation Rules
+
+    When a reviewer or implementer surfaces an issue, triage it:
 
     | Rule | Trigger | Action |
     |------|---------|--------|
-    | 1: Auto-fix bug | Code doesn't work as intended | Fix inline, document |
-    | 2: Auto-add critical | Missing validation, auth, error handling | Fix inline, document |
-    | 3: Auto-fix blocker | Missing dep, broken import, wrong types | Fix inline, document |
+    | 1: Auto-fix bug | Code doesn't work as intended | Dispatch implementer to fix, document |
+    | 2: Auto-add critical | Missing validation, auth, error handling | Dispatch implementer to fix, document |
+    | 3: Auto-fix blocker | Missing dep, broken import, wrong types | Dispatch implementer to fix, document |
     | 4: STOP | Architectural change (new table, library swap, breaking API) | Stop immediately — report to orchestrate context with: what change is needed, which task triggered it, and why the plan doesn't cover it |
 
     Only fix issues caused by the current task. Pre-existing issues go to the deferred
-    list. After 3 failed fix attempts, stop and document.
+    list. After 3 failed fix attempts on the same issue, stop and document.
 
     ## When All Tasks Are Done
 


### PR DESCRIPTION
## Summary
- Renamed phase executor to phase dispatcher to reinforce its role as a dispatcher-only agent that never writes code directly
- Added subagent hierarchy diagram to SKILL.md showing the dispatch structure: 1 phase dispatcher per phase, 1 implementer per task
- Updated prompt identity, deviation rules, and all references across both files

## Context
In practice, the phase executor was implementing all tasks directly instead of dispatching separate implementer subagents per task. The "executor" name encouraged this — renaming to "dispatcher" makes the role unambiguous.

## Test plan
- Verified no stale `phase executor` or `phase-executor` references remain via grep
- File rename detected cleanly by git (57% similarity)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated system architecture from phase executor to dispatcher-based model
  * Clarified role hierarchy and responsibilities across phases
  * Refined workflow processes and phase completion reporting
  * Enhanced prompt templates and integration guidelines for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->