### PR TITLE
refactor: run orchestrate in main agent context

### DIFF
--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -7,7 +7,7 @@ description: Use when you have a spec or requirements for a multi-step task, bef
 
 Write implementation plans assuming the executor has zero codebase context. Document everything: which files to touch, exact code, how to test, what to avoid and why.
 
-**Context:** Runs as a fresh subagent dispatched by design after design approval. All needed context comes from the design doc — no live conversation context is carried over.
+**Context:** Runs after design approval. All needed context comes from the design doc.
 
 **Save to:** `docs/plans/YYYY-MM-DD-<topic>/plan-<topic>.md`
 
@@ -19,7 +19,7 @@ Write implementation plans assuming the executor has zero codebase context. Docu
 4. **Write tasks** — Each task follows required structure
 5. **Save plan** — Write to plan file with frontmatter
 6. **Run plan review** — Dispatch reviewer, fix issues until clean
-7. **Hand off to execution** — Dispatch fresh orchestrator
+7. **Hand off to execution** — Report plan path to user
 
 ## Plan Document Structure
 
@@ -141,19 +141,6 @@ After saving, dispatch plan-review before execution. Plans with issues get fixed
 
 Skipping review risks plans with missing paths or ordering bugs reaching execution where they're harder to fix.
 
-## Execution Handoff
+## After Review Passes
 
-After review passes, dispatch a fresh Opus orchestrator with zero planning context (automatic `/clear`).
-
-Prompt includes: plan file path, working directory, instruction to use `orchestrate`, instruction to use `ship` when complete.
-
-```text
-Agent(
-  subagent_type: "general-purpose",
-  model: "opus",
-  prompt: "Read the plan at docs/plans/<folder>/plan-<topic>.md and execute
-    using orchestrate. When complete, use
-    implementation-review then ship.
-    Working directory: <worktree-path>"
-)
-```
+Report the plan file path to the user. Run orchestrate in the main context where it can interact with the user for Rule 4 escalations and ship decisions.

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -50,9 +50,11 @@ For each phase (letter A, B, C...):
    - Extract current phase section (from `## Phase X` through end of that phase's tasks, before next `## Phase`)
    - Dispatcher does NOT receive the plan header/goal/architecture or other phases' task details — context isolation prevents the dispatcher from being overwhelmed by irrelevant details
 4. Dispatch phase dispatcher (`./phase-dispatcher-prompt.md`) with: prior completion notes as PRIOR_COMPLETION_NOTES, current phase section (checklist + tasks), PHASE_BASE_SHA
-5. After dispatcher returns: dispatch implementation-review (`skills/implementation-review/reviewer-prompt.md`)
-   - BASE_SHA = PHASE_BASE_SHA, HEAD_SHA = `git rev-parse HEAD`
-6. Triage findings through deviation rules (see `./phase-dispatcher-prompt.md` for full table) — dispatch implementer for Rule 1-3. Rule 4 violations: dispatcher writes BLOCKED to plan, orchestrator terminates.
+5. After dispatcher returns:
+   - If it reported Rule 4 → ask the user directly and pause execution (see Rule 4 Handling). Do not proceed to implementation-review on partial work.
+   - Otherwise → dispatch implementation-review (`skills/implementation-review/reviewer-prompt.md`)
+     - BASE_SHA = PHASE_BASE_SHA, HEAD_SHA = `git rev-parse HEAD`
+6. Triage review findings through deviation rules (see `./phase-dispatcher-prompt.md` for full table) — dispatch implementer for Rule 1-3; Rule 4 → ask user and pause (see Rule 4 Handling)
 7. Re-Review Gate: >5 issues from any reviewer → re-review after all fixes applied
 8. Append implementation review changes to `### Phase X Completion Notes` (dispatcher already wrote its summary there; orchestrator appends review fixes below it)
 9. Emit phase summary: "Phase A complete. [N tasks]. Review: X issues — [brief list]. [All fixed / N deferred]."
@@ -91,6 +93,17 @@ Phase B BASE_SHA = $(git rev-parse HEAD)
 
 Handoff notes live as blockquotes on individual tasks, not as separate sections. The plan author places placeholders on target tasks (e.g., `> **Handoff from A2:** [TBD]` on B2). The Phase A dispatcher fills in actual details (real function signatures, file paths, config keys) after completing the producing task. The orchestrator does not write separate handoff notes sections.
 
+## Rule 4 Handling
+
+When a phase dispatcher reports a Rule 4 violation, ask the user directly — orchestrate runs in the main agent context. Present:
+
+- **What:** The architectural change needed
+- **Where:** Phase X, Task XN — task title
+- **Why:** What the implementer tried and why the plan doesn't cover it
+- **Options:** Update the plan to include the change, or adjust task scope to avoid it
+
+Do not attempt subsequent tasks or phases until the user decides.
+
 ## Plan Doc Updates
 
 | When | Update |
@@ -102,7 +115,7 @@ Handoff notes live as blockquotes on individual tasks, not as separate sections.
 | Phase review passes | Phase status: `Complete (YYYY-MM-DD)` |
 | Phase PR shipped | Ship creates PR with stacked base branch |
 | All phases done | Frontmatter: `status: Complete` |
-| Rule 4 violation | Frontmatter: `status: BLOCKED` + blocked_by + blocked_at |
+| Rule 4 violation | Ask user, pause execution until resolved |
 
 ## Key Constraints
 
@@ -113,7 +126,7 @@ Handoff notes live as blockquotes on individual tasks, not as separate sections.
 | Dispatch implementation-review from orchestrate context | Phase completion and any issues must be visible before advancing — prevents bugs compounding |
 | Fix review issues before next phase | Phase N bugs compound into Phase N+1 complexity |
 | Ship per-phase PR with stacked base | Each PR shows only its phase's diff, making review manageable |
-| Escalate Rule 4 immediately | Architectural changes need user input, not guessing |
+| Escalate Rule 4 immediately | Ask the user — architectural changes need human judgment |
 
 ## Integration
 

--- a/skills/orchestrate/phase-dispatcher-prompt.md
+++ b/skills/orchestrate/phase-dispatcher-prompt.md
@@ -78,7 +78,7 @@ Task tool (general-purpose):
     | 1: Auto-fix bug | Code doesn't work as intended | Dispatch implementer to fix, document |
     | 2: Auto-add critical | Missing validation, auth, error handling | Dispatch implementer to fix, document |
     | 3: Auto-fix blocker | Missing dep, broken import, wrong types | Dispatch implementer to fix, document |
-    | 4: STOP | Architectural change (new table, library swap, breaking API) | Stop immediately — report to orchestrate context with: what change is needed, which task triggered it, and why the plan doesn't cover it |
+    | 4: STOP | Architectural change (new table, library swap, breaking API) | Stop immediately — report to orchestrate context with: what change is needed, which task triggered it, and why the plan doesn't cover it. Orchestrate will ask the user directly. |
 
     Only fix issues caused by the current task. Pre-existing issues go to the deferred
     list. After 3 failed fix attempts on the same issue, stop and document.


### PR DESCRIPTION
## Summary
- Move orchestrate from subagent (dispatched by draft-plan) to main agent context
- Replace BLOCKED doc workaround with direct user interaction for Rule 4 escalations
- Update draft-plan to return plan path instead of dispatching execution subagent

## Test plan
- Verified all Rule 4 references are consistent across orchestrate/SKILL.md, phase-dispatcher-prompt.md
- Verified no stale "dispatched by draft-plan" or "BLOCKED" references remain
- Verified workflow has no unintended user touchpoints between orchestrate start and ship

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Shortened and generalized post-design-approval guidance; plan context now comes from the design doc.
  * Plan handoff updated: report the plan path to the user and run orchestration in the main context for escalations and ship decisions.
  * Rule 4 handling revised: orchestration now asks the user and pauses execution until resolution instead of blocking or terminating.
  * Minor wording tweaks clarifying prompts and pause semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->