### PR TITLE
chore: track docs/ directory in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@
 .claude/*
 !.claude/CLAUDE.md
 .DS_Store
-docs/plans/
-docs/reviews/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Replace heavy-handed `MUST`/`NEVER`/`ALWAYS` patterns with reasoning that explai
 ```text
 skills/           — One directory per skill (SKILL.md + optional supporting files)
 docs/plans/       — Design docs and implementation plans
+docs/reviews/     — Codebase review reports
 .claude-plugin/   — Plugin manifest and marketplace config
 ```
 


### PR DESCRIPTION
## Summary
- Remove `docs/plans/` and `docs/reviews/` from .gitignore so design docs and plans are version-controlled
- Add `docs/reviews/` to CLAUDE.md repo structure section
- Include 16 existing design docs and plans across 9 projects

## Test plan
- Verify all plan files appear in the PR diff
- Confirm no sensitive files were included

Co-Authored-By: Claude <noreply@anthropic.com>