### PR TITLE
fix: wrap hooks.json in required top-level hooks key

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -32,7 +32,7 @@
     {
       "name": "claude-caliper-workflow",
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → ship → merge",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -54,7 +54,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit and skill evaluation",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,16 +1,18 @@
 {
-  "PostToolUse": [{
-    "matcher": "AskUserQuestion",
-    "hooks": [{
-      "type": "command",
-      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use-design-approval.sh"
+  "hooks": {
+    "PostToolUse": [{
+      "matcher": "AskUserQuestion",
+      "hooks": [{
+        "type": "command",
+        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use-design-approval.sh"
+      }]
+    }],
+    "PermissionRequest": [{
+      "matcher": "Edit|Write",
+      "hooks": [{
+        "type": "command",
+        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-accept-edits.sh"
+      }]
     }]
-  }],
-  "PermissionRequest": [{
-    "matcher": "Edit|Write",
-    "hooks": [{
-      "type": "command",
-      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-accept-edits.sh"
-    }]
-  }]
+  }
 }


### PR DESCRIPTION
## Summary
- Plugin loader expects `{ "hooks": { ...events } }` but hooks.json had event types at root level, causing `TypeError: J?.reduce is not a function` on `/reload-plugins`
- Wrapped `PostToolUse` and `PermissionRequest` inside a `"hooks"` key to match the expected plugin hooks schema (verified against code-review-graph plugin format)
- Bumped version to 1.8.1

## Test plan
- [x] Verified code-review-graph 1.8.3 uses nested `{ "hooks": { ... } }` format
- [ ] Run `/reload-plugins` after merge — should load without TypeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)