### PR TITLE
fix(ship,merge-pr): use explicit origin HEAD for push in worktrees

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -31,7 +31,7 @@
     {
       "name": "claude-caliper-workflow",
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → ship → merge",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -53,7 +53,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit and skill evaluation",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/skills/merge-pr/SKILL.md
+++ b/skills/merge-pr/SKILL.md
@@ -66,7 +66,7 @@ Use AskUserQuestion with options:
 
 If `--skip-fixes` was passed, skip this entire step.
 
-For each actionable item: make the fix. Run project tests — do not merge with failing tests. Commit and push.
+For each actionable item: make the fix. Run project tests — do not merge with failing tests. Commit and push with `git push -u origin HEAD`.
 
 ### Step 6: Comment on PR
 
@@ -91,7 +91,7 @@ git fetch origin $DEFAULT_BRANCH
 git merge-base --is-ancestor origin/$DEFAULT_BRANCH HEAD
 ```
 
-If behind (non-zero exit): rebase onto default branch, resolve conflicts, run tests, push `--force-with-lease`. Comment on PR with conflict resolution details. Complex conflicts → stop and ask user.
+If behind (non-zero exit): rebase onto default branch, resolve conflicts, run tests, push with `git push -u origin HEAD --force-with-lease`. Always use `origin HEAD` explicitly — worktrees lose upstream tracking after rebase, so bare `git push` fails. Comment on PR with conflict resolution details. Complex conflicts → stop and ask user.
 
 **CWD safety:** Always `cd "$MAIN_REPO"` before merging — merge triggers remote branch deletion which bricks the shell if CWD is inside the worktree.
 

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -86,7 +86,7 @@ If conflicts occur, resolve them and re-run tests before continuing.
 git push -u origin HEAD
 ```
 
-If branch was rebased and already has remote, use `git push --force-with-lease`.
+If branch was rebased and already has remote, use `git push -u origin HEAD --force-with-lease`. Always use `origin HEAD` explicitly — worktrees lose upstream tracking after rebase, so bare `git push` fails.
 
 ### Step 8: Create PR
 


### PR DESCRIPTION
## Summary
- Worktrees lose upstream tracking after rebase, causing bare `git push` to fail
- Updated ship Step 7 and merge-pr Steps 5/8 to always use `git push -u origin HEAD` (with `--force-with-lease` after rebase)
- Hit this exact bug while merging PR #91

## Test plan
- [x] Verified the failure mode: `git push --force-with-lease` fails in worktree after rebase
- [x] `git push -u origin HEAD --force-with-lease` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)