### PR TITLE
fix: add hooks to bundle plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,6 +15,7 @@
         "email": "nikhil5890@gmail.com"
       },
       "strict": false,
+      "hooks": "./config/hooks.json",
       "skills": [
         "./skills/design",
         "./skills/design-review",


### PR DESCRIPTION
## Summary
- The `hooks` declaration was only on `claude-caliper-workflow` but not on the `claude-caliper` bundle plugin
- Users with the bundle installed got no hook auto-approvals (safe-commands, design-approval, acceptEdits)

## Test plan
- [ ] `/reload-plugins` shows 5 hooks (3 from bundle + 2 from code-review-graph)
- [ ] `mkdir -p /tmp/test` auto-approved without permission prompt
- [ ] Design approval flow creates `.design-approved` sentinel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended plugin configuration capabilities with hooks support for the Claude Caliper plugin, enabling enhanced plugin functionality and customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->