### PR TITLE
fix: use hookSpecificOutput wrapper in PreToolUse hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.9.2",
+      "version": "1.9.3",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -31,7 +31,7 @@
     {
       "name": "claude-caliper-workflow",
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → ship → merge",
-      "version": "1.9.2",
+      "version": "1.9.3",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -52,7 +52,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit and skill evaluation",
-      "version": "1.9.2",
+      "version": "1.9.3",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/hooks/pretooluse-safe-commands.sh
+++ b/hooks/pretooluse-safe-commands.sh
@@ -9,7 +9,7 @@ tool_name=$(echo "$input" | jq -r '.tool_name // empty')
 
 case "$tool_name" in
   Read|Glob|Grep|Skill|WebFetch|WebSearch|ToolSearch)
-    printf '{"permissionDecision":"allow"}\n'
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}\n'
     exit 0
     ;;
   Bash) ;;
@@ -220,7 +220,7 @@ for seg in "${segments[@]+"${segments[@]}"}"; do
 done
 
 if [[ $all_safe -eq 1 ]]; then
-  printf '{"permissionDecision":"allow"}\n'
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}\n'
 else
   for nm in "${non_matching[@]}"; do
     printf '%s\n' "$nm" >> "$LOG_FILE"


### PR DESCRIPTION
## Summary
- PreToolUse hooks require `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}` format, not the simple `{"permissionDecision":"allow"}`
- The simple format was silently ignored, causing all Bash commands to still prompt for permission despite the hook loading correctly (5 hooks visible in `/reload-plugins`)

## Test plan
- [x] 48/48 hook tests pass
- [ ] `/reload-plugins` then `mkdir -p /tmp/test` auto-approved without prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)