### PR TITLE
feat(orchestrate): bootstrap dependencies in phase worktrees

### DIFF
--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -79,9 +79,11 @@ For each phase being dispatched:
    | `pnpm-lock.yaml` | `pnpm install --frozen-lockfile` |
    | `Cargo.toml` | `cargo fetch` |
    | `go.mod` | `go mod download` |
-   | None of the above | Skip (no deps to install) |
+   | None of the above | Symlink fallback (see below) |
 
-   This ensures bare commands (`pytest`, `node`, `cargo test`) resolve correctly inside the worktree. Only runs once per phase — tasks inherit the environment.
+   **Symlink fallback:** If no manifest is detected, check the main repo root for existing environment directories (`.venv`, `node_modules`). If found, symlink them into the worktree (`ln -s /abs/path/to/main-repo/.venv .venv`). This handles repos with manually-configured environments. Symlinking works because binaries resolve their runtime via `pyvenv.cfg` / `node_modules` resolution, not the venv's absolute path. If neither manifest nor existing environment is found, log a warning and continue — bare commands may fail on missing deps.
+
+   Only runs once per phase — tasks inherit the environment.
 4. Extract context from plan.json:
    - `PHASE_TASKS_JSON=$(jq '.phases[N].tasks' plan.json)`
    - `PLAN_DIR=$(dirname "$(realpath plan.json)")`


### PR DESCRIPTION
## Summary
- Worktrees don't inherit the main repo's `.venv` or `node_modules`, so bare commands like `pytest`/`node` fail on missing dependencies
- New step 3 in per-phase execution detects lockfiles/manifests (pyproject.toml, requirements.txt, package-lock.json, Cargo.toml, go.mod, etc.) and runs the matching install command once per phase before dispatching tasks
- Removes the need for ecosystem-specific variable threading (e.g. `VENV_BIN`) — bare commands just work after install

## Test plan
- [ ] Prompt-only change to orchestrate SKILL.md — no runtime code to test
- [ ] Verify step numbering is correct (3-16)
- [ ] Verify no changes to dispatcher or implementer prompts needed

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Phase execution now automatically detects and installs project dependencies from common dependency manifests before running tasks. Supports Python, Node.js, Rust, and Go projects. This improves overall reliability and eliminates manual dependency installation steps, ensuring commands execute correctly within project environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->