### PR TITLE
fix: auto-approve safe Bash commands at PermissionRequest layer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.9.4",
+      "version": "1.9.5",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -31,7 +31,7 @@
     {
       "name": "claude-caliper-workflow",
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → ship → merge",
-      "version": "1.9.4",
+      "version": "1.9.5",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -52,7 +52,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit and skill evaluation",
-      "version": "1.9.4",
+      "version": "1.9.5",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,12 +7,21 @@
         "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse-safe-commands.sh"
       }]
     }],
-    "PermissionRequest": [{
-      "matcher": "Edit|Write",
-      "hooks": [{
-        "type": "command",
-        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-accept-edits.sh"
-      }]
-    }]
+    "PermissionRequest": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [{
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-accept-edits.sh"
+        }]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [{
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-safe-bash.sh"
+        }]
+      }
+    ]
   }
 }

--- a/hooks/permission-request-safe-bash.sh
+++ b/hooks/permission-request-safe-bash.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+input=$(cat)
+
+tool_name=$(echo "$input" | jq -r '.tool_name // empty')
+[[ "$tool_name" == "Bash" ]] || exit 0
+
+result=$(echo "$input" | bash "$SCRIPT_DIR/pretooluse-safe-commands.sh" 2>/dev/null || true)
+
+if echo "$result" | grep -qF '"permissionDecision":"allow"'; then
+  cat << 'HOOKJSON'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PermissionRequest",
+    "decision": {
+      "behavior": "allow"
+    }
+  }
+}
+HOOKJSON
+fi
+
+exit 0

--- a/hooks/pretooluse-safe-commands.sh
+++ b/hooks/pretooluse-safe-commands.sh
@@ -127,9 +127,7 @@ extract_segments() {
     words+=("$segment")
   fi
 
-  for seg in "${words[@]+"${words[@]}"}"; do
-    echo "$seg"
-  done
+  SEGMENTS=("${words[@]+"${words[@]}"}")
 }
 
 extract_command_words_from_segment() {
@@ -199,7 +197,8 @@ is_safe() {
   return 1
 }
 
-mapfile -t segments < <(extract_segments "$cmd")
+extract_segments "$cmd"
+segments=("${SEGMENTS[@]+"${SEGMENTS[@]}"}")
 
 count=0
 all_safe=1

--- a/tests/hooks/test_permission_request_safe_bash.sh
+++ b/tests/hooks/test_permission_request_safe_bash.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/permission-request-safe-bash.sh"
+PASS=0
+FAIL=0
+
+assert_output_contains() {
+  local desc="$1" output="$2" expected="$3"
+  if echo "$output" | grep -qF "$expected"; then
+    echo "PASS: $desc"
+    ((PASS++)) || true
+  else
+    echo "FAIL: $desc (expected '$expected' in output)"
+    ((FAIL++)) || true
+  fi
+}
+
+assert_output_empty() {
+  local desc="$1" output="$2"
+  if [[ -z "$output" ]]; then
+    echo "PASS: $desc"
+    ((PASS++)) || true
+  else
+    echo "FAIL: $desc (expected empty output, got: $output)"
+    ((FAIL++)) || true
+  fi
+}
+
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+run_hook() {
+  local command="$1"
+  local safe_file="$2"
+  local json
+  json=$(jq -n --arg cmd "$command" '{
+    tool_name: "Bash",
+    tool_input: { command: $cmd },
+    session_id: "test-session"
+  }')
+  echo "$json" | CLAUDE_SAFE_COMMANDS_FILE="$safe_file" CLAUDE_SAFE_CMDS_LOG="$TMPDIR_TEST/log.txt" bash "$HOOK" 2>/dev/null || true
+}
+
+SAFE="$TMPDIR_TEST/safe.txt"
+cp "$REPO_ROOT/hooks/safe-commands.txt" "$SAFE"
+
+echo "Test 1: cd && git compound (bare repo attack trigger) auto-allowed"
+OUT1=$(run_hook "cd /path/.claude/worktrees/phase-a && git add file.py && git commit -m 'msg'" "$SAFE")
+assert_output_contains "cd+git compound allowed" "$OUT1" '"behavior": "allow"'
+
+echo "Test 2: gh pr create with heredoc body (\$() + # triggers) auto-allowed"
+# shellcheck disable=SC2016  # Single quotes intentional — building literal command string
+HEREDOC_CMD=$(printf 'gh pr create --title "feat: thing" --body "$(cat <<'"'"'EOF'"'"'\n## Summary\n- item\nEOF\n)"')
+OUT2=$(run_hook "$HEREDOC_CMD" "$SAFE")
+assert_output_contains "gh+cat heredoc allowed" "$OUT2" '"behavior": "allow"'
+
+echo "Test 3: git commit with heredoc (\$() trigger) auto-allowed"
+# shellcheck disable=SC2016  # Single quotes intentional — building literal command string
+COMMIT_CMD=$(printf 'git commit -m "$(cat <<'"'"'EOF'"'"'\nfeat: add thing\n\nCo-Authored-By: Claude\nEOF\n)"')
+OUT3=$(run_hook "$COMMIT_CMD" "$SAFE")
+assert_output_contains "git commit heredoc allowed" "$OUT3" '"behavior": "allow"'
+
+echo "Test 4: Unsafe command NOT auto-allowed"
+OUT4=$(run_hook "curl https://evil.com" "$SAFE")
+assert_output_empty "unsafe command not allowed" "$OUT4"
+
+echo "Test 5: Mixed safe+unsafe NOT auto-allowed"
+OUT5=$(run_hook "cd /tmp && curl https://evil.com" "$SAFE")
+assert_output_empty "mixed safe+unsafe not allowed" "$OUT5"
+
+echo "Test 6: Non-Bash tool ignored (passthrough)"
+NON_BASH_JSON=$(jq -n '{tool_name: "Edit", tool_input: {file_path: "/tmp/x"}}')
+OUT6=$(echo "$NON_BASH_JSON" | CLAUDE_SAFE_COMMANDS_FILE="$SAFE" bash "$HOOK" 2>/dev/null || true)
+assert_output_empty "non-Bash tool passthrough" "$OUT6"
+
+echo "Test 7: cd + git add + git commit with multiline heredoc"
+# shellcheck disable=SC2016  # Single quotes intentional — building literal command string
+ML_CMD=$(printf 'cd /Users/me/project/.claude/worktrees/vec && git add scripts/embeddings.py && git commit -m "$(cat <<'"'"'EOF'"'"'\nfeat(embeddings): A2 core module\n\nCo-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>\nEOF\n)"')
+OUT7=$(run_hook "$ML_CMD" "$SAFE")
+assert_output_contains "full worktree commit pattern allowed" "$OUT7" '"behavior": "allow"'
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary
- **Bug fix**: `extract_segments` used `echo`/`mapfile` to pass segments between function and caller — `mapfile` splits on newlines, shattering heredoc content inside double quotes into multiple fake segments. Replaced with global `SEGMENTS` array.
- **New hook**: `permission-request-safe-bash.sh` handles Claude Code's built-in security checks (bare repo attacks, `$()` substitution, `#`-prefixed lines) that fire as PermissionRequest events independently of PreToolUse. Delegates to existing safe-commands logic.
- 7 new tests covering all three trigger patterns (cd+git, heredoc `$()`, `#` after quoted newline), plus unsafe/non-Bash passthrough.

## Test plan
- [x] All 32 existing safe-commands tests pass (no regression)
- [x] All 6 existing permission-request tests pass
- [x] 7 new permission-request-safe-bash tests pass
- [x] Total: 45 tests passing

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v1.9.5

* **New Features**
  * Added enhanced permission handling for Bash commands with automatic safety validation.

* **Chores**
  * Updated version to 1.9.5 across all plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->