### PR TITLE
feat: shared worktree dependency bootstrap

### DIFF
--- a/docs/plans/2026-03-22-dep-bootstrap/plan.json
+++ b/docs/plans/2026-03-22-dep-bootstrap/plan.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "status": "Not Yet Started",
+  "status": "In Development",
   "workflow": "ship",
   "goal": "Make worktree dependency bootstrapping reliable across single-root repos, workspace-based monorepos, and multi-manifest repos, with clear failure reporting and tool availability fallbacks",
   "architecture": "Extract the bootstrap procedure to skills/design/dependency-bootstrap.md as a shared reference file. The design skill step 6 gains a sub-step that bootstraps deps via See reference before running tests. The orchestrate skill step 3 replaces its inline install table (~180 words) with a one-line summary plus a See reference to the same file, freeing token budget.",

--- a/docs/plans/2026-03-22-dep-bootstrap/plan.md
+++ b/docs/plans/2026-03-22-dep-bootstrap/plan.md
@@ -1,5 +1,5 @@
 ---
-status: Not Yet Started
+status: In Development
 ---
 
 # Make worktree dependency bootstrapping reliable across single-root repos, workspace-based monorepos, and multi-manifest repos, with clear failure reporting and tool availability fallbacks Implementation Plan


### PR DESCRIPTION
## Summary
- Extract worktree dependency bootstrap to shared `skills/design/dependency-bootstrap.md` with 4-tier detection (root manifests → workspace indicators → subdirectory scan → symlink fallback), Python tool fallback (`uv` → `python3 -m venv`), and failure handling (exit code check + user escalation)
- Add bootstrap sub-step to design SKILL.md step 6 (before baseline test run)
- Replace orchestrate SKILL.md inline install table (~180 words) with `**See:**` reference, trimming it under the 1,000-word cap

## Test plan
- [x] A1: `wc -w` confirms dependency-bootstrap.md under 400 words
- [x] A2: `grep` confirms design SKILL.md references dependency-bootstrap.md
- [x] A3: `grep` confirms orchestrate SKILL.md references shared file and no longer contains inline install table
- [x] A4: `jq` confirms all three plugin versions bumped to 1.9.7
- [x] Implementation review: 0 cross-task issues, all 4 success criteria met

🤖 Generated with [Claude Code](https://claude.com/claude-code)