### PR TITLE
fix: add mktemp to safe-commands allowlist

### DIFF
--- a/hooks/safe-commands.txt
+++ b/hooks/safe-commands.txt
@@ -16,6 +16,7 @@ head
 jq
 ls
 mkdir
+mktemp
 mv
 node
 npm


### PR DESCRIPTION
## Summary
- Adds `mktemp` to `hooks/safe-commands.txt` so test scripts and `validate-plan` don't trigger permission prompts during hook execution

## Test plan
- [x] Verified `mktemp` is used in 16+ files across tests and scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the set of permitted shell utilities for internal processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->