### PR TITLE
fix: resolve branch from plan dir in --check-workflow

### DIFF
--- a/scripts/validate-plan
+++ b/scripts/validate-plan
@@ -1199,7 +1199,7 @@ do_check_workflow() {
   }
 
   local current_branch
-  current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+  current_branch=$(git -C "$plan_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 
   if [[ "$current_branch" == integrate/* ]]; then
     for ((p=0; p<phase_count; p++)); do

--- a/tests/validate-plan/caliper-test_check_workflow.sh
+++ b/tests/validate-plan/caliper-test_check_workflow.sh
@@ -207,14 +207,19 @@ echo "Test 9: single-phase pr-create does not require final impl-review (fails o
 setup_plan_dir
 write_single_phase_plan "pr-create" "Complete"
 printf '[{"type":"design-review","scope":"design","verdict":"pass","remaining":0},{"type":"plan-review","scope":"plan","verdict":"pass","remaining":0},{"type":"impl-review","scope":"phase-a","verdict":"pass","remaining":0}]' > "$TMPDIR/reviews.json"
-GIT_TMPDIR=$(mktemp -d)
-git -C "$GIT_TMPDIR" init -b test-no-pr-branch >/dev/null 2>&1
-git -C "$GIT_TMPDIR" commit --allow-empty -m "init" >/dev/null 2>&1
-pushd "$GIT_TMPDIR" >/dev/null
 GH_MOCK_PR_COUNT=0 assert_fail "single-phase pr-create fails on PR state not final impl-review" "no PR found\|no final PR found\|gh pr list failed" \
   "$VALIDATE" --check-workflow "$TMPDIR/plan.json"
-popd >/dev/null
-rm -rf "$GIT_TMPDIR"
+
+echo "Test 9a: branch resolved from plan dir, not CWD (issue #158)"
+GIT_PLAN_DIR=$(mktemp -d)
+git -C "$GIT_PLAN_DIR" init -b fix/my-feature >/dev/null 2>&1
+git -C "$GIT_PLAN_DIR" commit --allow-empty -m "init" >/dev/null 2>&1
+write_single_phase_plan "pr-create" "Complete"
+cp "$TMPDIR/plan.json" "$GIT_PLAN_DIR/plan.json"
+printf '[{"type":"design-review","scope":"design","verdict":"pass","remaining":0},{"type":"plan-review","scope":"plan","verdict":"pass","remaining":0},{"type":"impl-review","scope":"phase-a","verdict":"pass","remaining":0}]' > "$GIT_PLAN_DIR/reviews.json"
+GH_MOCK_PR_COUNT=0 assert_fail "branch from plan dir not CWD" "no PR found for fix/my-feature" \
+  "$VALIDATE" --check-workflow "$GIT_PLAN_DIR/plan.json"
+rm -rf "$GIT_PLAN_DIR"
 
 echo "Test 9b: single-phase pr-create fails when missing phase impl-review"
 setup_plan_dir


### PR DESCRIPTION
## Summary
- `validate-plan --check-workflow` used CWD's `git rev-parse` to determine the current branch, which resolved to `main` when the orchestrator ran from the main repo instead of the feature worktree
- Fixed by using `git -C "$plan_dir"` to resolve the branch from the plan's worktree context
- Added regression test (9a) that verifies the branch is read from the plan directory

Closes #158

## Test plan
- [x] All 12 existing + new tests pass (`bash tests/validate-plan/caliper-test_check_workflow.sh`)
- [x] New test 9a creates a plan inside a git repo on `fix/my-feature` and confirms the error references that branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validate-plan to correctly determine the current branch when invoked from different working directories.

* **Tests**
  * Enhanced test coverage for workflow validation to verify proper behavior across different execution contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->