### PR TITLE
fix: prompt for review_mode when not explicitly configured

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.21.1",
+      "version": "1.21.2",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.21.1",
+      "version": "1.21.2",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.21.1",
+      "version": "1.21.2",
 
       "source": "./",
       "author": {

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -25,9 +25,16 @@ If not on PR branch: use existing worktree if found (`cd` into it), otherwise `g
 
 If `--automated`/`-A` passed, use automated mode. `--automated` + `--skip-fixes` is invalid — fail fast.
 
-If no flag, check `${CLAUDE_PLUGIN_ROOT}/scripts/caliper-settings get review_mode`. If `automated`, use it. Otherwise prompt:
-- **Automated** — Fix all actionable findings without interaction.
-- **Deliberate** — Collect all feedback, present unified triage, choose what to fix.
+If no flag, check whether the user explicitly configured a preference:
+
+```bash
+source=$("${CLAUDE_PLUGIN_ROOT}/scripts/caliper-settings" source review_mode)
+```
+
+- If `source` = `user`: use their configured value from `caliper-settings get review_mode` without prompting.
+- If `source` = `default`: prompt the user to choose — the default is just a fallback, not an explicit preference:
+  - **Automated** — Fix all actionable findings without interaction.
+  - **Deliberate** — Collect all feedback, present unified triage, choose what to fix.
 
 ### Step 3: Rebase onto Base Branch
 


### PR DESCRIPTION
## Summary
- pr-review Step 2 was using `caliper-settings get review_mode` and treating the shipped default (`deliberate`) as an explicit user choice, skipping the mode selection prompt
- Now uses `caliper-settings source review_mode` to check if the user explicitly configured the setting — only skips the prompt when `source=user`
- Bumps version to 1.21.2

## Test plan
- [ ] Run `/pr-review` without setting `review_mode` — should prompt for automated vs deliberate
- [ ] Run `caliper-settings set review_mode deliberate` then `/pr-review` — should use deliberate without prompting
- [ ] Run `/pr-review --automated` — should use automated regardless of setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated three plugins to version 1.21.2.

* **Improvements**
  * Refined preference handling to distinguish between explicitly configured user settings and default values. User-set preferences are now automatically respected without additional prompts, while system defaults trigger selection only when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->