### PR TITLE
fix: pass stripped word to is_safe in safe-commands hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.21.2",
+      "version": "1.21.3",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.21.2",
+      "version": "1.21.3",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.21.2",
+      "version": "1.21.3",
 
       "source": "./",
       "author": {

--- a/hooks/pretooluse-safe-commands.sh
+++ b/hooks/pretooluse-safe-commands.sh
@@ -313,9 +313,9 @@ for seg in "${segments[@]+"${segments[@]}"}"; do
       continue
     fi
     count=$((count+1))
-    if ! is_safe "$word"; then
+    if ! is_safe "$stripped"; then
       all_safe=0
-      non_matching+=("$word")
+      non_matching+=("$stripped")
     fi
   done
 done

--- a/tests/hooks/caliper-test_safe_commands.sh
+++ b/tests/hooks/caliper-test_safe_commands.sh
@@ -423,6 +423,20 @@ printf 'caliper-test_*\nchmod\n' > "$SAFE43"
 OUT43=$(run_hook "chmod +x tests/hooks/caliper-test_safe_commands.sh && ./tests/hooks/caliper-test_safe_commands.sh" "$SAFE43" "$LOG43")
 assert_output_contains "prefix glob works in compound commands" "$OUT43" "allow"
 
+echo "Test 44: Quoted absolute path matches after quote stripping"
+SAFE44="$TMPDIR_TEST/safe44.txt"
+LOG44="$TMPDIR_TEST/log44.txt"
+printf 'caliper-settings\n' > "$SAFE44"
+OUT44=$(run_hook '"/Users/nsitaram/.claude/plugins/marketplaces/claude-caliper/scripts/caliper-settings" get merge_strategy' "$SAFE44" "$LOG44")
+assert_output_contains "quoted absolute path allowed after stripping" "$OUT44" "allow"
+
+echo "Test 45: Single-quoted absolute path matches after quote stripping"
+SAFE45="$TMPDIR_TEST/safe45.txt"
+LOG45="$TMPDIR_TEST/log45.txt"
+printf 'caliper-settings\n' > "$SAFE45"
+OUT45=$(run_hook "'/Users/nsitaram/.claude/plugins/marketplaces/claude-caliper/scripts/caliper-settings' get merge_strategy" "$SAFE45" "$LOG45")
+assert_output_contains "single-quoted absolute path allowed after stripping" "$OUT45" "allow"
+
 echo ""
 echo "$PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary
- Fix `pretooluse-safe-commands.sh` passing raw `$word` (with quotes) to `is_safe()` instead of `$stripped` — quoted absolute paths like `"/path/to/caliper-settings"` now match the safe list correctly
- Add tests for double-quoted and single-quoted absolute path scenarios (tests 44-45)
- Bump version to 1.21.3

Closes #163

## Test plan
- [x] All 57 existing tests pass
- [x] New test 44: double-quoted absolute path (`"/path/to/script"`) matches safe list
- [x] New test 45: single-quoted absolute path (`'/path/to/script'`) matches safe list

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command validation handling for quoted command paths.

* **Chores**
  * Updated plugin versions to 1.21.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->