### PR TITLE
fix: auto-allow Bash commands on plan artifact paths

### DIFF
--- a/hooks/permission-request-safe-bash.sh
+++ b/hooks/permission-request-safe-bash.sh
@@ -8,6 +8,21 @@ input=$(cat)
 tool_name=$(echo "$input" | jq -r '.tool_name // empty')
 [[ "$tool_name" == "Bash" ]] || exit 0
 
+cmd=$(echo "$input" | jq -r '.tool_input.command // empty')
+if [[ -n "$cmd" && "$cmd" == *"/.claude/claude-caliper/"* ]]; then
+  cat << 'HOOKJSON'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PermissionRequest",
+    "decision": {
+      "behavior": "allow"
+    }
+  }
+}
+HOOKJSON
+  exit 0
+fi
+
 result=$(echo "$input" | bash "$SCRIPT_DIR/pretooluse-safe-commands.sh" 2>/dev/null || true)
 
 if echo "$result" | grep -qF '"permissionDecision":"allow"'; then

--- a/tests/hooks/caliper-test_permission_request.sh
+++ b/tests/hooks/caliper-test_permission_request.sh
@@ -83,6 +83,34 @@ else
   ((PASS++)) || true
 fi
 
+BASH_HOOK="$REPO_ROOT/hooks/permission-request-safe-bash.sh"
+
+echo "Test 6: Bash rm on .claude/claude-caliper/ path auto-allowed"
+INPUT6=$(jq -n --arg cwd "$TMPDIR" '{cwd: $cwd, tool_name: "Bash", tool_input: {command: "rm /some/project/.claude/claude-caliper/2026-03-31-topic/phase-a/a7.md"}}')
+OUTPUT6=$(echo "$INPUT6" | bash "$BASH_HOOK" 2>/dev/null)
+assert_output_contains "Bash rm on plan path auto-allowed" "$OUTPUT6" '"behavior": "allow"'
+
+echo "Test 7: Bash mkdir on .claude/claude-caliper/ path auto-allowed"
+INPUT7=$(jq -n --arg cwd "$TMPDIR" '{cwd: $cwd, tool_name: "Bash", tool_input: {command: "mkdir -p /project/.claude/claude-caliper/2026-03-31-topic/phase-b"}}')
+OUTPUT7=$(echo "$INPUT7" | bash "$BASH_HOOK" 2>/dev/null)
+assert_output_contains "Bash mkdir on plan path auto-allowed" "$OUTPUT7" '"behavior": "allow"'
+
+echo "Test 8: Bash on non-plan .claude/ path NOT auto-allowed (falls through)"
+INPUT8=$(jq -n --arg cwd "$TMPDIR" '{cwd: $cwd, tool_name: "Bash", tool_input: {command: "rm /project/.claude/settings.json"}}')
+OUTPUT8=$(echo "$INPUT8" | bash "$BASH_HOOK" 2>/dev/null)
+if echo "$OUTPUT8" | grep -qF '"behavior": "allow"'; then
+  echo "FAIL: non-plan .claude/ path should not be auto-allowed"
+  ((FAIL++)) || true
+else
+  echo "PASS: non-plan .claude/ path not auto-allowed"
+  ((PASS++)) || true
+fi
+
+echo "Test 9: Non-Bash tool ignored by bash hook"
+INPUT9=$(jq -n --arg cwd "$TMPDIR" '{cwd: $cwd, tool_name: "Edit", tool_input: {command: "rm /.claude/claude-caliper/foo"}}')
+OUTPUT9=$(echo "$INPUT9" | bash "$BASH_HOOK" 2>/dev/null)
+assert_output_empty "non-Bash tool ignored" "$OUTPUT9"
+
 echo ""
 echo "$PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary
- Bash commands (rm, mkdir, etc.) targeting `.claude/claude-caliper/` plan artifacts triggered Claude Code's sensitive file permission prompt
- Added path-based auto-allow to `permission-request-safe-bash.sh`, matching the pattern `permission-request-accept-edits.sh` already uses for Edit/Write
- Added 4 tests covering plan path allow, non-plan .claude/ deny, and tool filtering

## Test plan
- [x] All 14 permission request tests pass
- [x] Bash `rm` on plan path auto-allowed
- [x] Bash on `.claude/settings.json` NOT auto-allowed
- [x] Non-Bash tools ignored by bash hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added four new test cases for permission request handling, including scenarios for Bash operations on specific paths and verification of non-Bash tool handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->