### PR TITLE
fix: revert hooks.json to working format

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,8 +31,7 @@
         "./skills/pr-merge",
         "./skills/skill-eval",
         "./skills/caliper-settings"
-      ],
-      "hooks": "./hooks/hooks.json"
+      ]
     },
     {
       "name": "claude-caliper-workflow",
@@ -58,8 +57,7 @@
         "./skills/pr-review",
         "./skills/pr-merge",
         "./skills/caliper-settings"
-      ],
-      "hooks": "./hooks/hooks.json"
+      ]
     },
     {
       "name": "claude-caliper-tooling",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,26 +1,25 @@
-[
-  {
-    "event": "PreToolUse",
+{
+  "PreToolUse": [{
     "matcher": "*",
     "hooks": [{
       "type": "command",
       "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse-safe-commands.sh"
     }]
-  },
-  {
-    "event": "PermissionRequest",
-    "matcher": "Edit|Write",
-    "hooks": [{
-      "type": "command",
-      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-accept-edits.sh"
-    }]
-  },
-  {
-    "event": "PermissionRequest",
-    "matcher": "Bash",
-    "hooks": [{
-      "type": "command",
-      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-safe-bash.sh"
-    }]
-  }
-]
+  }],
+  "PermissionRequest": [
+    {
+      "matcher": "Edit|Write",
+      "hooks": [{
+        "type": "command",
+        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-accept-edits.sh"
+      }]
+    },
+    {
+      "matcher": "Bash",
+      "hooks": [{
+        "type": "command",
+        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-safe-bash.sh"
+      }]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Reverts hooks.json from array format back to flat object format (keyed by event type)
- Removes `"hooks"` field from marketplace.json — auto-discovery from `hooks/hooks.json` handles loading
- PR #168 broke hooks by switching to array format; auto-discovery expects an object

Co-Authored-By: Claude <noreply@anthropic.com>