### PR TITLE
fix: restore required hooks wrapper key in hooks.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.22.1",
+      "version": "1.22.2",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.22.1",
+      "version": "1.22.2",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.22.1",
+      "version": "1.22.2",
 
       "source": "./",
       "author": {

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,25 +1,27 @@
 {
-  "PreToolUse": [{
-    "matcher": "*",
-    "hooks": [{
-      "type": "command",
-      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse-safe-commands.sh"
-    }]
-  }],
-  "PermissionRequest": [
-    {
-      "matcher": "Edit|Write",
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "*",
       "hooks": [{
         "type": "command",
-        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-accept-edits.sh"
+        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse-safe-commands.sh"
       }]
-    },
-    {
-      "matcher": "Bash",
-      "hooks": [{
-        "type": "command",
-        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-safe-bash.sh"
-      }]
-    }
-  ]
+    }],
+    "PermissionRequest": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [{
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-accept-edits.sh"
+        }]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [{
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-safe-bash.sh"
+        }]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Restores the `"hooks"` wrapper key in `hooks/hooks.json` that PR #169 incorrectly removed
- The Zod validator expects `{ "hooks": { "PreToolUse": [...], ... } }`, not event types at the root
- Bumps version to 1.22.2

## Root cause
PR #169 reverted to flat format based on stale debugging context, but the validator has always required the wrapper. The working format was last seen at PR #99 (`67454e9`).

## Test plan
- [ ] `/reload-plugins` shows 0 errors
- [ ] `/plugin` Errors tab is empty
- [ ] Hooks count > 0 in reload output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin versions to 1.22.2 across claude-caliper, claude-caliper-workflow, and claude-caliper-tooling
  * Reorganized configuration file structure with no functional changes to hook behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->