### PR TITLE
fix: use AskUserQuestion in pr-review, drop worktree nav advice

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.23.0",
+      "version": "1.24.0",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.23.0",
+      "version": "1.24.0",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.23.0",
+      "version": "1.24.0",
 
       "source": "./",
       "author": {

--- a/skills/pr-create/SKILL.md
+++ b/skills/pr-create/SKILL.md
@@ -111,10 +111,6 @@ When `--base` is provided (e.g., from orchestrate for phase PRs), the PR targets
 
 Report: branch name, test results, files changed, commit hash, PR URL.
 
-If running inside a worktree, tell the user:
-
-> PR is open for review. When ready to address feedback: `/exit` this session, `cd` to the main repo, then run `/pr-review`. Starting fresh from the main repo avoids worktree CWD issues during cleanup.
-
 ## Arguments
 
 | Arg | Effect |

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -32,7 +32,7 @@ mode=$("${CLAUDE_PLUGIN_ROOT}/scripts/caliper-settings" get review_mode)
 ```
 
 - If a mode is returned (`automated` or `deliberate`): the user explicitly configured this. Use it.
-- If `PROMPT_REQUIRED`: no explicit preference — prompt the user to choose:
+- If `PROMPT_REQUIRED`: no explicit preference — use AskUserQuestion to ask:
   - **Automated** — Fix all actionable findings without interaction.
   - **Deliberate** — Collect all feedback, present unified triage, choose what to fix.
 


### PR DESCRIPTION
## Summary
- pr-review Step 2: changed "prompt the user to choose" → "use AskUserQuestion to ask" so the agent uses the tool instead of printing text
- pr-create Step 9: removed worktree exit/cd advice — pr-review handles worktree detection, ExitWorktree handles cleanup from any CWD
- Version bump to 1.24.0

## Test plan
- [x] All 73 tests pass (caliper-settings, hooks, validate-plan)
- [ ] Run `/pr-review` in deliberate mode and verify AskUserQuestion is used for mode selection

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin versions to 1.24.0

* **Documentation**
  * Removed worktree-specific guidance from PR creation documentation
  * Updated PR review mode selection instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->