### PR TITLE
chore: bump version to 1.27.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.26.0",
+      "version": "1.27.0",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.26.0",
+      "version": "1.27.0",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.26.0",
+      "version": "1.27.0",
 
       "source": "./",
       "author": {


### PR DESCRIPTION
## Summary
- Bump plugin version from 1.26.0 → 1.27.0 for PR #179 changes (review gate enforcement at transition time, orchestrate phase activation step)

## Test plan
- [ ] Verify marketplace.json has 1.27.0 in all three plugin entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin versions to 1.27.0 for claude-caliper, claude-caliper-workflow, and claude-caliper-tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->