### PR TITLE
fix(orchestrate): reset shell CWD after agent worktree removal

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.27.0",
+      "version": "1.27.1",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.27.0",
+      "version": "1.27.1",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.27.0",
+      "version": "1.27.1",
 
       "source": "./",
       "author": {

--- a/skills/orchestrate/dispatch-subagents.md
+++ b/skills/orchestrate/dispatch-subagents.md
@@ -80,9 +80,10 @@ For trivial tasks (one-liner, config change, rename) where a full reviewer dispa
 2. Mark task complete: `scripts/validate-plan --update-status plan.json --task {TASK_ID} --status complete`
 3. Validate criteria: `scripts/validate-plan --criteria plan.json --task {TASK_ID}`
 4. Merge and clean up the agent's worktree:
-   - Use `git -C <your worktree path> merge <agent-branch>` — the `-C` flag ensures the merge targets the integration/feature branch regardless of current shell CWD, which can drift after processing agent completions
-   - After merge: `git worktree remove <agent-worktree-path>` then `git branch -d <agent-branch>`
-   - Verify your CWD is still in the integration/feature worktree with `pwd`; if it drifted, `cd` back
+   - Never `cd` into an agent worktree — always use `git -C <agent-worktree-path>` for inspection commands (`git log`, `git status`, `git diff`). This prevents CWD from pointing at a path that gets deleted during cleanup.
+   - Merge: `git -C <your worktree path> merge <agent-branch>`
+   - Clean up: `git worktree remove <agent-worktree-path>` then `git branch -d <agent-branch>`
+   - Reset CWD after removal: `cd <feature-worktree-path> && pwd` — run this after every worktree removal even if you believe CWD hasn't drifted
 5. Check if dependent tasks are now unblocked (`scripts/validate-plan --check-deps`)
 6. Dispatch newly unblocked tasks (same pattern as above)
 


### PR DESCRIPTION
## Summary
- Replace advisory "verify and cd back if needed" with deterministic `cd <feature-worktree-path> && pwd` after every worktree removal
- Add preventive rule: never `cd` into agent worktrees — use `git -C` for all inspection commands
- Bump version 1.27.0 → 1.27.1

Closes #178

## Test plan
- Verified dispatch-subagents.md step 4 wording is clear and prescriptive
- Confirmed version bump in all three plugin entries

Co-Authored-By: Claude <noreply@anthropic.com>