### PR TITLE
fix: add missing comma in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.28.0"
+      "version": "1.28.0",
 
       "source": "./",
       "author": {


### PR DESCRIPTION
## Summary
- Missing comma after `"version": "1.28.0"` in the `claude-caliper-tooling` plugin entry was causing a JSON parse error when loading the plugin.

## Test plan
- [ ] Validate `marketplace.json` parses cleanly: `python3 -c "import json; json.load(open('.claude-plugin/marketplace.json'))"`
- [ ] Reload the plugin and confirm no parse error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->