### PR TITLE
fix(validate-plan): resolve branch from CWD, not plan.json path

### DIFF
--- a/bin/validate-plan
+++ b/bin/validate-plan
@@ -682,11 +682,8 @@ do_check_base() {
   local json
   json=$(cat "$plan_json")
 
-  local plan_dir
-  plan_dir="$(cd "$(dirname "$plan_json")" && pwd)"
-
   local current_branch
-  current_branch=$(git -C "$plan_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
   if [[ -z "$current_branch" ]]; then
     echo "ERROR: not in a git repository" >&2
     exit 1

--- a/tests/validate-plan/caliper-test_check_base.sh
+++ b/tests/validate-plan/caliper-test_check_base.sh
@@ -100,6 +100,21 @@ jq '.integration_branch = ""' "$TMPDIR/plan.json" > "$TMPDIR/plan2.json" && mv "
 assert_fail "empty integration_branch fails" "base_branch_mismatch" \
   run_in_dir "$TMPDIR" "$VALIDATE" --check-base "$TMPDIR/plan.json"
 
+echo "Test 6: plan.json in main repo, CWD in feature worktree passes (issue 189)"
+MAIN_REPO="$TMPDIR/main-repo"
+WORKTREE_DIR="$TMPDIR/worktree-feat"
+mkdir -p "$MAIN_REPO" "$WORKTREE_DIR"
+init_git_repo "$MAIN_REPO"
+init_git_repo "$WORKTREE_DIR"
+git -C "$WORKTREE_DIR" checkout -b feat/cross-dir -q 2>/dev/null
+setup_valid_plan "$MAIN_REPO"
+assert_pass "plan.json in main repo, CWD in feature worktree" \
+  run_in_dir "$WORKTREE_DIR" "$VALIDATE" --check-base "$MAIN_REPO/plan.json"
+
+echo "Test 7: plan.json in main repo, CWD on main branch fails (issue 189)"
+assert_fail "plan.json in main repo, CWD on main branch" "base_branch_mismatch" \
+  run_in_dir "$MAIN_REPO" "$VALIDATE" --check-base "$MAIN_REPO/plan.json"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 exit $FAIL


### PR DESCRIPTION
## Summary
- `--check-base` used `git -C "$plan_dir"` to determine the current branch, resolving from the plan.json directory instead of CWD. When plan.json lives in the main repo's `.claude/` dir and CWD is a feature worktree, this incorrectly returned `main` and failed with `base_branch_mismatch`.
- Fix: remove `-C "$plan_dir"` so `git rev-parse` uses CWD.
- Added two tests covering the cross-directory scenario (plan.json in one repo, CWD in another).

Closes #189

## Test plan
- All 7 `--check-base` tests pass (5 existing + 2 new)
- Test 6 validates the exact bug scenario: plan.json in main repo, CWD in feature worktree
- Test 7 confirms the guard still catches CWD on main

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined Git operation handling in the validation process to improve support for different repository configurations and working directory setups.

* **Tests**
  * Added comprehensive test scenarios validating the validation system's behavior with Git worktrees, feature branches, and repository misconfigurations, ensuring proper error detection for branch mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->