### PR TITLE
feat(draft-plan): task consolidation heuristic

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.33.0",
+      "version": "1.34.0",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.33.0",
+      "version": "1.34.0",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.33.0",
+      "version": "1.34.0",
 
       "source": "./",
       "author": {

--- a/agents/plan-reviewer.md
+++ b/agents/plan-reviewer.md
@@ -58,7 +58,7 @@ For each task with test steps:
 - Test imports from correct path?
 - Function signatures match between test and implementation?
 - Return values consistent?
-- TDD 5-step cycle present? (write fail, verify fail, implement, verify pass, commit)
+- TDD 5-step cycle present? (write fail, verify fail, implement, verify pass, commit) Exception: consolidated mechanical tasks may specify suite-level verification instead — verify the task is clearly mechanical and the verification command is runnable.
 
 For multi-task plans with cross-task data flow:
 - First task (e.g., A1) as broad integration tests present?

--- a/agents/task-implementer.md
+++ b/agents/task-implementer.md
@@ -17,7 +17,7 @@ You are working in an isolated git worktree. All code changes, file creation, an
 
 1. Follow TDD for all implementation — the cycle is: Write failing test -> verify it FAILS -> write minimal code -> verify it PASSES -> refactor -> commit. **Never skip verifying the test fails first.** A test that passes before implementation protects nothing. **See:** `skills/orchestrate/tdd.md` for test discovery, failure mode troubleshooting, and boundary test patterns. **Exception:** Consolidated mechanical tasks (renames, import additions, config updates across multiple files) may specify a lighter verification in their prose — e.g., "run the full test suite and confirm no regressions." Follow whatever discipline the task prose prescribes.
 2. If this task consumes output from a prior task (imports a module, reads config, calls an API created earlier), write a narrow boundary integration test using real components as part of your TDD cycle
-3. Implement exactly what the task specifies using TDD (red/green/refactor)
+3. Implement exactly what the task specifies using the discipline prescribed in the task prose (TDD by default; consolidated mechanical tasks may specify suite-level verification instead)
 4. Verify implementation works
 5. Commit your work
 6. Self-review (see below)

--- a/agents/task-implementer.md
+++ b/agents/task-implementer.md
@@ -15,7 +15,7 @@ You are working in an isolated git worktree. All code changes, file creation, an
 
 ## Your Job
 
-1. Follow TDD for all implementation — the cycle is: Write failing test -> verify it FAILS -> write minimal code -> verify it PASSES -> refactor -> commit. **Never skip verifying the test fails first.** A test that passes before implementation protects nothing. **See:** `skills/orchestrate/tdd.md` for test discovery, failure mode troubleshooting, and boundary test patterns.
+1. Follow TDD for all implementation — the cycle is: Write failing test -> verify it FAILS -> write minimal code -> verify it PASSES -> refactor -> commit. **Never skip verifying the test fails first.** A test that passes before implementation protects nothing. **See:** `skills/orchestrate/tdd.md` for test discovery, failure mode troubleshooting, and boundary test patterns. **Exception:** Consolidated mechanical tasks (renames, import additions, config updates across multiple files) may specify a lighter verification in their prose — e.g., "run the full test suite and confirm no regressions." Follow whatever discipline the task prose prescribes.
 2. If this task consumes output from a prior task (imports a module, reads config, calls an API created earlier), write a narrow boundary integration test using real components as part of your TDD cycle
 3. Implement exactly what the task specifies using TDD (red/green/refactor)
 4. Verify implementation works

--- a/agents/task-reviewer.md
+++ b/agents/task-reviewer.md
@@ -38,6 +38,7 @@ Check commit history within the diff range.
 
 - Flag: Implementation commit with no preceding test commit
 - Flag: All code in a single commit (no TDD cycle visible)
+- **Exception:** Consolidated mechanical tasks (renames, imports, config updates) may use a single commit with suite-level verification instead of per-change TDD cycles. Check the task prose — if it specifies lighter verification, evaluate against that standard instead.
 
 ### 3. Test Quality
 Read every test file in the diff.

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -137,7 +137,7 @@ Every task splits metadata (plan.json) and prose (task .md file).
 | Field | Requirement | Good |
 |-------|-------------|------|
 | **Avoid + WHY** | Pitfalls with reasoning | "Use jose not jsonwebtoken — CJS/Edge issues" |
-| **Steps** | TDD cycle per step | Write failing test, verify fail, implement, verify pass, commit |
+| **Steps** | TDD cycle per step (consolidated mechanical tasks: list changes + suite-level verification) | Write failing test, verify fail, implement, verify pass, commit |
 
 Write complete code in each step — not "add validation" or "implement the handler."
 

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -110,6 +110,15 @@ Phase boundaries = meaningful "run full suite" points. Each phase gets `phase-{l
 
 Inherit phases from design doc if approved.
 
+## Task Consolidation
+
+Each task carries fixed overhead: worktree creation, subagent dispatch, and a review cycle. Trivial tasks (single-line changes, import additions, config updates) don't justify that cost individually. Before finalizing tasks, scan for consolidation opportunities:
+
+- **Bundle mechanical changes:** If multiple files each need small, mechanical edits (renaming an export, adding an import, updating a config value), combine them into one task. A single task can span many files as long as the changes are cohesive and the verification is straightforward.
+- **Keep substantive tasks separate:** Changes that require design decisions, new logic, or non-trivial testing should remain their own task — consolidation is for rote work, not for collapsing genuinely independent features.
+- **Rule of thumb:** If a task's prose would be shorter than its plan.json metadata, it's too small — look for neighbors to merge with.
+- **TDD for consolidated tasks:** Mechanical changes don't need per-file red/green cycles. In the task prose, specify a single verification pass (e.g., "run the full test suite and confirm no regressions") rather than step-by-step TDD. The implementer follows whatever discipline the task prose prescribes.
+
 ## Task Structure
 
 Every task splits metadata (plan.json) and prose (task .md file).


### PR DESCRIPTION
## Summary
- Adds task consolidation guidance to draft-plan: bundle trivial mechanical changes (renames, imports, config updates) into fewer tasks to reduce subagent dispatch overhead
- Updates task-implementer to accept suite-level verification for consolidated tasks instead of requiring per-change TDD cycles
- Updates task-reviewer to not flag missing TDD discipline when task prose specifies lighter verification

## Test plan
- [x] All 275 existing tests pass
- [x] No validate-plan changes needed — consolidated tasks are structurally identical to regular tasks
- [x] Version bumped to 1.34.0

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped three plugin versions to 1.34.0

* **Documentation**
  * Clarified verification guidance to allow suite-level checks for consolidated mechanical tasks
  * Added task consolidation guidance for batching small mechanical edits and updated task/reviewer checklists accordingly
<!-- end of auto-generated comment: release notes by coderabbit.ai -->