### PR TITLE
fix(orchestrate): explicit teammate shutdown and spawn format for agent teams

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.34.0",
+      "version": "1.35.0",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.34.0",
+      "version": "1.35.0",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.34.0",
+      "version": "1.35.0",
 
       "source": "./",
       "author": {

--- a/skills/orchestrate/dispatch-agent-teams.md
+++ b/skills/orchestrate/dispatch-agent-teams.md
@@ -6,6 +6,10 @@ Dispatch protocol for executing plan tasks via agent team teammates. Requires `C
 
 Before dispatching any teammates, verify: `[[ "$CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" == "1" ]]`. If not set, abort with an error — the design skill should have caught this during mode selection, but this guards against direct orchestrate invocation.
 
+## Create Team
+
+Before spawning any teammates, create the team: `TeamCreate({team_name: "{PLAN_NAME}"})` where `{PLAN_NAME}` is derived from the plan (e.g., branch name or plan title, kebab-cased). Store as `TEAM_NAME`.
+
 ## Spawn Implementer Teammates
 
 For each task in the phase, check deps: `validate-plan --check-deps "$PLAN_JSON" --task {TASK_ID}`. Collect all tasks that pass. For each ready task, extract metadata (strip `status` — orchestrator state not needed by implementer):
@@ -14,7 +18,7 @@ For each task in the phase, check deps: `validate-plan --check-deps "$PLAN_JSON"
 TASK_METADATA=$(jq -c --arg id "{TASK_ID}" '[.phases[].tasks[] | select(.id == $id)][0] | del(.status)' "$PLAN_JSON")
 ```
 
-Spawn **all ready implementer teammates in a single message** — one TeamCreate per task, all in the same turn. Splitting spawns across turns breaks parallelism. Each teammate:
+Spawn **all ready implementer teammates in a single message** — one Agent call per task, all in the same turn. Splitting spawns across turns breaks parallelism. Each teammate:
 - Uses `claude-caliper:task-implementer` agent with dynamic context from `./implementer-prompt.md`
 - Gets its own auto-provisioned worktree
 - Manages its own lifecycle (marks in-progress, writes completion notes, marks complete)
@@ -27,16 +31,16 @@ When an implementer teammate goes idle (push notification — no polling):
 
 1. Read the teammate's completion notes (`{PHASE_DIR}/{TASK_ID_LOWER}-completion.md`)
 2. Dispatch a `claude-caliper:task-reviewer` teammate with dynamic context from `./task-reviewer-prompt.md`, using the task's branch-specific diff range (task worktree `BASE..HEAD`, not the phase-wide range)
-3. When reviewer goes idle, extract the last `json review-summary` block
+3. When reviewer goes idle, extract the last `json review-summary` block. Shut down the reviewer immediately: `SendMessage({to: "review-{TASK_ID_LOWER}", message: {type: "shutdown_request"}})`
 4. Triage issues: "fix" (send to implementer via mailbox) or "dismiss" (document reasoning)
-5. If fixes needed: send review feedback to the *original implementer* via mailbox messaging — the implementer still has context and files. Implementer fixes and goes idle again. Repeat until review passes.
+5. If fixes needed: send review feedback to the *original implementer* via mailbox messaging — the implementer still has context and files. Implementer fixes and goes idle again. Dispatch a new reviewer teammate, repeat until review passes.
 6. Validate with `validate-plan --criteria plan.json --task {TASK_ID}`
-7. Kill teammate only after review passes and criteria met
+7. Shut down implementer after review passes and criteria met: `SendMessage({to: "impl-{TASK_ID_LOWER}", message: {type: "shutdown_request"}})`. Wait for the teammate's idle notification confirming shutdown before proceeding — the teammate must fully terminate before its worktree can be removed.
 8. **Record task-review:** Write a passing record to `reviews.json` (in the plan directory): `jq '. += [{"type":"task-review","scope":"{TASK_ID}","verdict":"pass","remaining":0}]' "$PLAN_DIR/reviews.json" > "$PLAN_DIR/reviews.json.tmp" && mv "$PLAN_DIR/reviews.json.tmp" "$PLAN_DIR/reviews.json"`. Create the file (`echo '[]'`) if it doesn't exist. For trivial tasks where review is overhead, use `"verdict":"skip","reason":"<justification>"` instead.
 9. **Incremental merge:** Merge this task's branch into the feature/integration branch so dependent tasks see prerequisite code. Use `git -C <your worktree path> merge <task-branch>` — the `-C` flag prevents CWD drift that occurs after processing teammate completions. After merge: `git worktree remove <teammate-worktree-path>` then `git branch -d <task-branch>`. Verify CWD with `pwd`; if it drifted, `cd` back.
 10. **Dependency gate:** Check if any blocked tasks are now unblocked. For each candidate, run `validate-plan --check-deps plan.json --task {TASK_ID}`. If all dependencies are complete, spawn a new implementer teammate for that task (worktree created from the now-updated feature branch).
 
-**Phase completion gate:** Lead cannot advance until ALL teammates for this phase (implementers and reviewers) are terminated.
+**Phase completion gate:** Lead cannot advance until ALL teammates for this phase (implementers and reviewers) are terminated. After the last teammate shuts down, call `TeamDelete()` to clean up team resources.
 
 ## Handle Escalations
 
@@ -44,28 +48,34 @@ Teammates send Rule 4 violations (architectural changes) to lead via mailbox. Le
 
 ## Teammate Spawn Format
 
-Implementer teammates use the template in `./implementer-prompt.md`. Key spawn parameters:
+Spawn teammates using the Agent tool with explicit `team_name`, `mode`, and `subagent_type` parameters. These parameters must appear directly in the Agent tool call — YAML descriptions are not sufficient.
 
-```yaml
-Teammate spawn:
-  name: "impl-{TASK_ID_LOWER}"
-  subagent_type: "claude-caliper:task-implementer"
-  model: "{TASK_IMPLEMENTER_MODEL}"
-  mode: "acceptEdits"
-  description: "Implement {TASK_ID}: [task name]"
+Implementer teammates use the template in `./implementer-prompt.md`:
+
+```text
+Agent({
+  team_name: "{TEAM_NAME}",
+  name: "impl-{TASK_ID_LOWER}",
+  subagent_type: "claude-caliper:task-implementer",
+  model: "{TASK_IMPLEMENTER_MODEL}",
+  mode: "acceptEdits",
+  description: "Implement {TASK_ID}: [task name]",
   prompt: <filled from implementer-prompt.md template, omitting {WORKTREE_PATH} — the teammate uses its auto-provisioned CWD>
+})
 ```
 
-Task reviewer teammates use the template in `./task-reviewer-prompt.md`. Key spawn parameters:
+Task reviewer teammates use the template in `./task-reviewer-prompt.md`:
 
-```yaml
-Teammate spawn:
-  name: "review-{TASK_ID_LOWER}"
-  subagent_type: "claude-caliper:task-reviewer"
-  model: "{TASK_REVIEWER_MODEL}"
-  mode: "auto"
-  description: "Review Task {TASK_ID}"
+```text
+Agent({
+  team_name: "{TEAM_NAME}",
+  name: "review-{TASK_ID_LOWER}",
+  subagent_type: "claude-caliper:task-reviewer",
+  model: "{TASK_REVIEWER_MODEL}",
+  mode: "auto",
+  description: "Review Task {TASK_ID}",
   prompt: <filled from task-reviewer-prompt.md template>
+})
 ```
 
-Both templates document their required variables and full prompt content.
+`mode: "acceptEdits"` is critical for implementers — without it, every Edit/Write call prompts the lead for approval, blocking parallel execution. Both templates document their required variables and full prompt content.

--- a/skills/orchestrate/dispatch-agent-teams.md
+++ b/skills/orchestrate/dispatch-agent-teams.md
@@ -31,7 +31,7 @@ When an implementer teammate goes idle (push notification — no polling):
 
 1. Read the teammate's completion notes (`{PHASE_DIR}/{TASK_ID_LOWER}-completion.md`)
 2. Dispatch a `claude-caliper:task-reviewer` teammate with dynamic context from `./task-reviewer-prompt.md`, using the task's branch-specific diff range (task worktree `BASE..HEAD`, not the phase-wide range)
-3. When reviewer goes idle, extract the last `json review-summary` block. Shut down the reviewer immediately: `SendMessage({to: "review-{TASK_ID_LOWER}", message: {type: "shutdown_request"}})`
+3. When reviewer goes idle, extract the last `json review-summary` block. Shut down the reviewer: `SendMessage({to: "review-{TASK_ID_LOWER}", message: {type: "shutdown_request"}})` and wait for the idle notification confirming shutdown before proceeding — if step 5 re-dispatches a reviewer with the same name, the previous instance must be fully terminated to avoid name collisions.
 4. Triage issues: "fix" (send to implementer via mailbox) or "dismiss" (document reasoning)
 5. If fixes needed: send review feedback to the *original implementer* via mailbox messaging — the implementer still has context and files. Implementer fixes and goes idle again. Dispatch a new reviewer teammate, repeat until review passes.
 6. Validate with `validate-plan --criteria plan.json --task {TASK_ID}`
@@ -40,7 +40,7 @@ When an implementer teammate goes idle (push notification — no polling):
 9. **Incremental merge:** Merge this task's branch into the feature/integration branch so dependent tasks see prerequisite code. Use `git -C <your worktree path> merge <task-branch>` — the `-C` flag prevents CWD drift that occurs after processing teammate completions. After merge: `git worktree remove <teammate-worktree-path>` then `git branch -d <task-branch>`. Verify CWD with `pwd`; if it drifted, `cd` back.
 10. **Dependency gate:** Check if any blocked tasks are now unblocked. For each candidate, run `validate-plan --check-deps plan.json --task {TASK_ID}`. If all dependencies are complete, spawn a new implementer teammate for that task (worktree created from the now-updated feature branch).
 
-**Phase completion gate:** Lead cannot advance until ALL teammates for this phase (implementers and reviewers) are terminated. After the last teammate shuts down, call `TeamDelete()` to clean up team resources.
+**Phase completion gate:** Lead cannot advance until ALL teammates for this phase (implementers and reviewers) are terminated. After the final phase completes (not each phase), call `TeamDelete()` to clean up team resources — the team persists across phases so dependent tasks in later phases can be dispatched to new teammates without recreating the team.
 
 ## Handle Escalations
 


### PR DESCRIPTION
## Summary
- Add explicit `SendMessage` shutdown_request calls for both implementer and reviewer teammates, plus `TeamDelete` cleanup after phase completion
- Replace abstract YAML spawn format with concrete `Agent({...})` call examples including `mode: "acceptEdits"` and `team_name` parameters
- Add `TeamCreate` section before spawns; fix incorrect "one TeamCreate per task" wording

Fixes #181

## Test plan
- Spawned an agent team with `subagent_type: "claude-caliper:task-implementer"`, `mode: "acceptEdits"`, `model: "haiku"` to verify agent definition propagation
- Confirmed agent definition body, model, and mode parameters are passed correctly
- Verified teammate shutdown via `SendMessage` shutdown_request and `TeamDelete` cleanup

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin versions to 1.35.0 for claude-caliper, claude-caliper-workflow, and claude-caliper-tooling.

* **Documentation**
  * Refined team orchestration workflow documentation with updated team creation procedures, reviewer lifecycle management, implementer shutdown behavior, and teammate spawning requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->