### PR TITLE
feat(pr-review): add automated-merge mode

### DIFF
--- a/bin/caliper-settings
+++ b/bin/caliper-settings
@@ -48,7 +48,19 @@ cmd_get() {
   local key="${1:?get requires a key}"
   validate_key "$key"
   if echo "$SETTINGS" | jq -e --arg k "$key" 'has($k)' > /dev/null 2>&1; then
-    echo "$SETTINGS" | jq -r --arg k "$key" '.[$k] | tostring'
+    local value type
+    value=$(echo "$SETTINGS" | jq -r --arg k "$key" '.[$k] | tostring')
+    type=$(echo "$DEFAULTS" | jq -r --arg k "$key" '.[$k].type')
+    if [[ "$type" == "enum" ]] && ! echo "$DEFAULTS" | jq -e --arg k "$key" --arg v "$value" '.[$k].values | index($v)' > /dev/null 2>&1; then
+      echo "WARNING: stored value '$value' for $key is no longer valid, ignoring" >&2
+      if echo "$DEFAULTS" | jq -e --arg k "$key" '.[$k].prompt_required == true' > /dev/null 2>&1; then
+        echo "PROMPT_REQUIRED"
+      else
+        echo "$DEFAULTS" | jq -r --arg k "$key" '.[$k].default'
+      fi
+    else
+      echo "$value"
+    fi
   elif echo "$DEFAULTS" | jq -e --arg k "$key" '.[$k].prompt_required == true' > /dev/null 2>&1; then
     echo "PROMPT_REQUIRED"
   else

--- a/defaults.json
+++ b/defaults.json
@@ -7,7 +7,7 @@
   },
   "review_mode": {
     "type": "enum",
-    "values": ["automated", "deliberate"],
+    "values": ["automated-fix", "automated-merge", "deliberate"],
     "prompt_required": true,
     "description": "PR review mode (prompted each time unless explicitly set)",
     "used_by": ["pr-review"]

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -105,7 +105,7 @@ Skip integration branch and phase worktrees. Work directly in the feature worktr
 5. `validate-plan --update-status "$PLAN_JSON" --plan --status Complete`
 6. Route on workflow:
    - `"pr-create"`: invoke pr-create (targets main), `validate-plan --check-workflow "$PLAN_JSON"`, stop
-   - `"pr-merge"`: invoke pr-create, read `REVIEW_WAIT=$(caliper-settings get review_wait_minutes)`, poll checks + pr-review --automated (skip if $REVIEW_WAIT is 0; if skipped, invoke pr-merge directly), `validate-plan --check-workflow "$PLAN_JSON"`
+   - `"pr-merge"`: invoke pr-create, read `REVIEW_WAIT=$(caliper-settings get review_wait_minutes)`, poll checks + pr-review --automated-merge (skip if $REVIEW_WAIT is 0; if skipped, invoke pr-merge directly), `validate-plan --check-workflow "$PLAN_JSON"`
 
 ## After All Phases (Multi-Phase Only)
 
@@ -114,7 +114,7 @@ Skip integration branch and phase worktrees. Work directly in the feature worktr
 3. `validate-plan --check-review "$PLAN_JSON" --type impl-review --scope final`
 4. `validate-plan --update-status "$PLAN_JSON" --plan --status Complete`
 5. Route on workflow:
-   - `"pr-merge"`: create final PR, poll checks, pr-review --automated, `validate-plan --check-workflow "$PLAN_JSON"`, clean up
+   - `"pr-merge"`: create final PR, poll checks, pr-review --automated-merge, `validate-plan --check-workflow "$PLAN_JSON"`, clean up
    - `"pr-create"`: create final PR, `validate-plan --check-workflow "$PLAN_JSON"`, stop
 
 **Continuity:** Run continuously. Pause only for Rule 4 violations.

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -23,7 +23,7 @@ If not on PR branch: use existing worktree if found (`cd` into it), otherwise `g
 
 ### Step 2: Mode Selection
 
-If `--automated-fix`/`-A` passed, use automated-fix mode. If `--automated-merge`/`-M` passed, use automated-merge mode. Either automated flag + `--skip-fixes` is invalid — fail fast.
+If `--automated-fix`/`-A` passed, use automated-fix mode. If `--automated-merge`/`-M` passed, use automated-merge mode. Both flags together is invalid — fail fast. Either automated flag + `--skip-fixes` is also invalid — fail fast.
 
 If no flag, read the user's preference:
 
@@ -116,7 +116,7 @@ Skip if `--skip-fixes`. Fix each item, run tests (fail = stop), commit and push.
 
 Post `gh pr comment`: what was fixed, dismissed (with reasons), no-action. Omit empty sections.
 
-Report PR URL and item counts. Automated-merge mode: invoke pr-merge. Automated-fix and deliberate modes: offer merge or tell user to run `/pr-merge` when ready.
+Report PR URL and item counts. Automated-merge mode: invoke pr-merge. Automated-fix mode: tell user to run `/pr-merge` when ready. Deliberate mode: offer merge or tell user to run `/pr-merge` when ready.
 
 ## Arguments
 

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -23,7 +23,7 @@ If not on PR branch: use existing worktree if found (`cd` into it), otherwise `g
 
 ### Step 2: Mode Selection
 
-If `--automated`/`-A` passed, use automated mode. `--automated` + `--skip-fixes` is invalid — fail fast.
+If `--automated-fix`/`-A` passed, use automated-fix mode. If `--automated-merge`/`-M` passed, use automated-merge mode. Either automated flag + `--skip-fixes` is invalid — fail fast.
 
 If no flag, read the user's preference:
 
@@ -31,9 +31,10 @@ If no flag, read the user's preference:
 mode=$(caliper-settings get review_mode)
 ```
 
-- If a mode is returned (`automated` or `deliberate`): the user explicitly configured this. Use it.
+- If a mode is returned (`automated-fix`, `automated-merge`, or `deliberate`): the user explicitly configured this. Use it.
 - If `PROMPT_REQUIRED`: no explicit preference — use AskUserQuestion to ask:
-  - **Automated** — Fix all actionable findings without interaction.
+  - **Automated fix** — Fix all actionable findings without interaction.
+  - **Automated merge** — Fix all actionable findings, then auto-merge the PR.
   - **Deliberate** — Collect all feedback, present unified triage, choose what to fix.
 
 ### Step 3: Rebase onto Base Branch
@@ -64,8 +65,8 @@ Subagent posts findings as `gh pr comment`, then returns them for Step 6.
 ### Step 5: External Feedback
 
 **Wait for bots:**
-- `--automated` from orchestrate: wait 90s, then poll `gh pr checks` every 30s (timeout: 5 min).
-- User-selected automated: wait 60s warm-up, then poll every 60s.
+- `--automated-merge` from orchestrate: wait 90s, then poll `gh pr checks` every 30s (timeout: 5 min).
+- User-selected automated (fix or merge): wait 60s warm-up, then poll every 60s.
 - Deliberate: no warm-up, poll every 60s.
 - Poll until all checks complete and no "processing"/"in progress" indicators in comments.
 - Bot rate-limit warning = treat as ready.
@@ -87,7 +88,7 @@ All three required — bots post to sources 2-3.
 | **Informational** — praise, explanation | Acknowledge |
 | **False positive** | Dismiss with reasoning |
 
-**Automated:** Fix actionable items, run tests. If `--skip-review` (no wave 2): commit and push. Otherwise: commit locally only (wave 2 may touch same files).
+**Automated (fix or merge):** Fix actionable items, run tests. If `--skip-review` (no wave 2): commit and push. Otherwise: commit locally only (wave 2 may touch same files).
 
 **Deliberate:** Collect and report. No fixes yet.
 
@@ -95,7 +96,7 @@ All three required — bots post to sources 2-3.
 
 Wait for background subagent (Step 4). Skip if `--skip-review`.
 
-**Automated:** Dismiss findings already fixed in wave 1. Fix remaining actionable items, run tests, commit and push (covers both waves).
+**Automated (fix or merge):** Dismiss findings already fixed in wave 1. Fix remaining actionable items, run tests, commit and push (covers both waves).
 
 **Deliberate:** Merge with Step 5 findings into unified set. Proceed to Step 7.
 
@@ -115,7 +116,7 @@ Skip if `--skip-fixes`. Fix each item, run tests (fail = stop), commit and push.
 
 Post `gh pr comment`: what was fixed, dismissed (with reasons), no-action. Omit empty sections.
 
-Report PR URL and item counts. Automated mode: invoke pr-merge. Deliberate mode: offer merge or tell user to run `/pr-merge` when ready.
+Report PR URL and item counts. Automated-merge mode: invoke pr-merge. Automated-fix and deliberate modes: offer merge or tell user to run `/pr-merge` when ready.
 
 ## Arguments
 
@@ -124,8 +125,9 @@ Report PR URL and item counts. Automated mode: invoke pr-merge. Deliberate mode:
 | `<PR number>` | Target specific PR |
 | *(none)* | Detect from current branch |
 | `--skip-review` / `-R` | Skip subagent review (Steps 4, 6) |
-| `--skip-fixes` / `-S` | Skip fixing — just comment (invalid with `--automated`) |
-| `--automated` / `-A` | Fix all actionable, no interaction |
+| `--skip-fixes` / `-S` | Skip fixing — just comment (invalid with automated modes) |
+| `--automated-fix` / `-A` | Fix all actionable, no interaction |
+| `--automated-merge` / `-M` | Fix all actionable, then auto-merge |
 
 ## Pitfalls
 


### PR DESCRIPTION
## Summary
- Split `automated` review mode into `automated-fix` (fix findings only) and `automated-merge` (fix findings then auto-invoke pr-merge)
- Orchestrate's `pr-merge` workflow now passes `--automated-merge` to chain review into merge
- Version bump to 1.35.0

## Test plan
- [ ] Run `/pr-review` without flags — prompt should show three options (automated fix, automated merge, deliberate)
- [ ] Run `/pr-review --automated-fix` — should fix and stop without merging
- [ ] Run `/pr-review --automated-merge` — should fix then invoke pr-merge
- [ ] Orchestrate with `pr-merge` workflow — should pass `--automated-merge` to pr-review

Co-Authored-By: Claude <noreply@anthropic.com>