### PR TITLE
feat(workflow): add orchestrate-only workflow mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.35.0",
+      "version": "1.36.0",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.35.0",
+      "version": "1.36.0",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.35.0",
+      "version": "1.36.0",
 
       "source": "./",
       "author": {

--- a/bin/validate-plan
+++ b/bin/validate-plan
@@ -104,7 +104,7 @@ do_schema() {
     err "ERROR: missing_field: workflow"
   else
     case "$workflow" in
-      "pr-create"|"pr-merge"|"plan-only") ;;
+      "pr-create"|"pr-merge"|"orchestrate"|"plan-only") ;;
       *) err "ERROR: invalid_workflow: $workflow" ;;
     esac
   fi
@@ -1249,6 +1249,15 @@ do_check_workflow() {
     if ! fr_result=$(check_review_record "$plan_dir" "impl-review" "final"); then
       gate_errors+=("impl-review final: $fr_result")
     fi
+  fi
+
+  if [[ "$workflow" == "orchestrate" ]]; then
+    if [[ ${#gate_errors[@]} -gt 0 ]]; then
+      echo "ERROR: workflow gate (orchestrate) unsatisfied:" >&2
+      for ge in "${gate_errors[@]}"; do echo "  - $ge" >&2; done
+      exit 1
+    fi
+    exit 0
   fi
 
   check_pr_exists() {

--- a/defaults.json
+++ b/defaults.json
@@ -27,7 +27,7 @@
   },
   "workflow": {
     "type": "enum",
-    "values": ["pr-create", "pr-merge", "plan-only"],
+    "values": ["pr-create", "pr-merge", "orchestrate", "plan-only"],
     "prompt_required": true,
     "description": "Post-orchestration workflow (prompted each time unless explicitly set)",
     "used_by": ["design", "orchestrate"]

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -38,6 +38,7 @@ Complete in order:
     - If `PROMPT_REQUIRED`: include in AskUserQuestion with recommended option marked "(Recommended)":
       - **Create PR** — Orchestrate → pr-create (Recommended)
       - **Merge PR** — Orchestrate → pr-create → pr-review → pr-merge
+      - **Orchestrate only** — Orchestrate → stop after implementation review (work stays in worktree)
       - **Plan only** — Stop after plan is reviewed
 
     **Q2 — Execution mode** (header: "Exec mode"):
@@ -74,7 +75,7 @@ Complete in order:
 10. **Dispatch design-review subagent** — fresh reviewer agent validates design before planning (hard gate)
 11. **Dispatch draft-plan subagent** — fresh implementer agent with design doc path and worktree path (zero design context)
 12. **Route workflow** — Map step 7 choices to schema values:
-    - Workflow: `Create PR` → `pr-create`, `Merge PR` → `pr-merge`, `Plan only` → `plan-only`
+    - Workflow: `Create PR` → `pr-create`, `Merge PR` → `pr-merge`, `Orchestrate only` → `orchestrate`, `Plan only` → `plan-only`
     - Exec mode: `Subagents` → `subagents`, `Agent teams` → `agent-teams`
 
     Write both: `jq --arg w "<workflow>" --arg e "<exec-mode>" '.workflow = $w | .execution_mode = $e' plan.json > tmp && mv tmp plan.json`
@@ -82,7 +83,7 @@ Complete in order:
     For multi-phase plans, also write the integration branch name:
     `jq --arg ib "integrate/<feature>" '.integration_branch = $ib' plan.json > tmp && mv tmp plan.json`
 
-    For **Create PR** or **Merge PR**: invoke orchestrate.
+    For **Create PR**, **Merge PR**, or **Orchestrate only**: invoke orchestrate.
     For **Plan only**: run `validate-plan --check-workflow plan.json` to verify design-review and plan-review passed. Report the plan file path and stop.
 
 Read the design reviewer model: `DESIGN_REVIEWER_MODEL=$(caliper-settings get design_reviewer_model)`

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -104,6 +104,7 @@ Skip integration branch and phase worktrees. Work directly in the feature worktr
 4. Run plan criteria: `validate-plan --criteria "$PLAN_JSON" --plan`
 5. `validate-plan --update-status "$PLAN_JSON" --plan --status Complete`
 6. Route on workflow:
+   - `"orchestrate"`: `validate-plan --check-workflow "$PLAN_JSON"`, report worktree path, stop
    - `"pr-create"`: invoke pr-create (targets main), `validate-plan --check-workflow "$PLAN_JSON"`, stop
    - `"pr-merge"`: invoke pr-create, read `REVIEW_WAIT=$(caliper-settings get review_wait_minutes)`, poll checks + pr-review --automated-merge (skip if $REVIEW_WAIT is 0; if skipped, invoke pr-merge directly), `validate-plan --check-workflow "$PLAN_JSON"`
 
@@ -114,6 +115,7 @@ Skip integration branch and phase worktrees. Work directly in the feature worktr
 3. `validate-plan --check-review "$PLAN_JSON" --type impl-review --scope final`
 4. `validate-plan --update-status "$PLAN_JSON" --plan --status Complete`
 5. Route on workflow:
+   - `"orchestrate"`: `validate-plan --check-workflow "$PLAN_JSON"`, report worktree path, stop
    - `"pr-merge"`: create final PR, poll checks, pr-review --automated-merge, `validate-plan --check-workflow "$PLAN_JSON"`, clean up
    - `"pr-create"`: create final PR, `validate-plan --check-workflow "$PLAN_JSON"`, stop
 

--- a/tests/validate-plan/caliper-test_check_workflow.sh
+++ b/tests/validate-plan/caliper-test_check_workflow.sh
@@ -167,6 +167,44 @@ assert_fail "plan-only missing reviews.json exits 1" "reviews.json not found" \
   "$VALIDATE" --check-workflow "$TMPDIR/plan.json"
 
 echo ""
+echo "=== orchestrate workflow ==="
+
+echo "Test 4a: orchestrate passes with all reviews and plan Complete"
+setup_plan_dir
+write_single_phase_plan "orchestrate" "Complete"
+printf '[{"type":"design-review","scope":"design","verdict":"pass","remaining":0},{"type":"plan-review","scope":"plan","verdict":"pass","remaining":0},{"type":"impl-review","scope":"phase-a","verdict":"pass","remaining":0}]' > "$TMPDIR/reviews.json"
+assert_pass "orchestrate with all reviews and Complete exits 0" \
+  "$VALIDATE" --check-workflow "$TMPDIR/plan.json"
+
+echo "Test 4b: orchestrate fails when plan not Complete"
+setup_plan_dir
+write_single_phase_plan "orchestrate" "In Development"
+printf '[{"type":"design-review","scope":"design","verdict":"pass","remaining":0},{"type":"plan-review","scope":"plan","verdict":"pass","remaining":0},{"type":"impl-review","scope":"phase-a","verdict":"pass","remaining":0}]' > "$TMPDIR/reviews.json"
+assert_fail "orchestrate with plan In Development exits 1" "plan status is" \
+  "$VALIDATE" --check-workflow "$TMPDIR/plan.json"
+
+echo "Test 4c: orchestrate fails missing impl-review"
+setup_plan_dir
+write_single_phase_plan "orchestrate" "Complete"
+printf '[{"type":"design-review","scope":"design","verdict":"pass","remaining":0},{"type":"plan-review","scope":"plan","verdict":"pass","remaining":0}]' > "$TMPDIR/reviews.json"
+assert_fail "orchestrate missing impl-review exits 1" "impl-review phase-a" \
+  "$VALIDATE" --check-workflow "$TMPDIR/plan.json"
+
+echo "Test 4d: orchestrate does not require PR (no gh calls)"
+setup_plan_dir
+write_single_phase_plan "orchestrate" "Complete"
+printf '[{"type":"design-review","scope":"design","verdict":"pass","remaining":0},{"type":"plan-review","scope":"plan","verdict":"pass","remaining":0},{"type":"impl-review","scope":"phase-a","verdict":"pass","remaining":0}]' > "$TMPDIR/reviews.json"
+GH_MOCK_PR_COUNT=0 assert_pass "orchestrate passes without any PR" \
+  "$VALIDATE" --check-workflow "$TMPDIR/plan.json"
+
+echo "Test 4e: multi-phase orchestrate requires final impl-review"
+setup_plan_dir
+write_two_phase_plan "orchestrate" "Complete"
+printf '[{"type":"design-review","scope":"design","verdict":"pass","remaining":0},{"type":"plan-review","scope":"plan","verdict":"pass","remaining":0},{"type":"impl-review","scope":"phase-a","verdict":"pass","remaining":0},{"type":"impl-review","scope":"phase-b","verdict":"pass","remaining":0}]' > "$TMPDIR/reviews.json"
+assert_fail "orchestrate two-phase without final impl-review exits 1" "impl-review final" \
+  "$VALIDATE" --check-workflow "$TMPDIR/plan.json"
+
+echo ""
 echo "=== pr-create workflow ==="
 
 echo "Test 5: pr-create fails when plan not Complete"

--- a/tests/validate-plan/caliper-test_schema.sh
+++ b/tests/validate-plan/caliper-test_schema.sh
@@ -239,6 +239,14 @@ jq '. + {"workflow": "plan-only"} | .phases[0] += {"depends_on": []} | .phases[1
 assert_pass "valid workflow plan-only passes" \
   "$VALIDATE" --schema "$TMPDIR/plan.json"
 
+echo "Test 23b: Valid workflow orchestrate passes"
+rm -rf "${TMPDIR:?}/"*
+cp -r "$FIXTURES/valid-plan/"* "$TMPDIR/"
+jq '. + {"workflow": "orchestrate"} | .phases[0] += {"depends_on": []} | .phases[1] += {"depends_on": ["A"]}' \
+  "$FIXTURES/valid-plan/plan.json" > "$TMPDIR/plan.json"
+assert_pass "valid workflow orchestrate passes" \
+  "$VALIDATE" --schema "$TMPDIR/plan.json"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- Adds `orchestrate` as a new workflow setting that runs full orchestration (task execution + implementation review) but stops before PR creation
- Work stays committed in the worktree for manual inspection or later `pr-create`
- Gate validation requires plan Complete + all impl-reviews passed, but no PR check

## Test plan
- [x] Schema validation accepts `orchestrate` as valid workflow (test 23b)
- [x] Workflow gate passes with all reviews + Complete status (test 4a)
- [x] Workflow gate fails when plan not Complete (test 4b)
- [x] Workflow gate fails when missing impl-review (test 4c)
- [x] Workflow gate passes without any PR existing (test 4d)
- [x] Multi-phase requires final impl-review (test 4e)
- [x] All existing tests still pass (28 schema, 17 workflow)

Co-Authored-By: Claude <noreply@anthropic.com>