### PR TITLE
fix(hooks): treat newlines as segment separators in extract_segments

### DIFF
--- a/hooks/lib-command-parser.sh
+++ b/hooks/lib-command-parser.sh
@@ -71,6 +71,15 @@ extract_segments() {
       continue
     fi
 
+    if [[ "$char" == $'\n' ]]; then
+      if [[ -n "${segment// }" ]]; then
+        words+=("$segment")
+      fi
+      segment=""
+      i=$((i+1))
+      continue
+    fi
+
     if [[ "$char" == "|" || "$char" == ";" ]]; then
       if [[ -n "${segment// }" ]]; then
         words+=("$segment")


### PR DESCRIPTION
## Summary
- `extract_segments` in `lib-command-parser.sh` didn't treat newlines as segment separators, so multi-line bash scripts were parsed as one giant segment
- `extract_command_words_from_segment` then extracted tokens like `then\n` (with a trailing newline) which failed the safe-commands lookup
- Result: fully-safe multi-line scripts (like the branch-detect script in `pr-create`) triggered unnecessary permission prompts

## Test plan
- Manually verified with a test script: the failing command now splits into 8 clean segments, extracting `git`, `if`, `then`, `fi`, `echo` — all in `safe-commands.txt`
- Newlines inside `$(...)` and quoted strings are unaffected (existing paren-depth and quote-tracking logic handles those before the newline check)

Co-Authored-By: Claude <noreply@anthropic.com>