### PR TITLE
fix(orchestrate): add mode: "acceptEdits" to all subagent dispatch templates

### DIFF
--- a/hooks/pretooluse-deny-patterns.sh
+++ b/hooks/pretooluse-deny-patterns.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=hooks/lib-command-parser.sh
 source "$SCRIPT_DIR/lib-command-parser.sh"
 
 input="$(cat)"
@@ -17,6 +18,7 @@ if [[ -z "$cmd" ]]; then
 fi
 
 extract_segments "$cmd"
+# shellcheck disable=SC2153
 segments=("${SEGMENTS[@]+"${SEGMENTS[@]}"}")
 
 for seg in "${segments[@]+"${segments[@]}"}"; do
@@ -48,12 +50,12 @@ for seg in "${segments[@]+"${segments[@]}"}"; do
         _rest="${_rest#"${_rest%%[![:space:]]*}"}"
         if [[ -n "$_rest" ]]; then
           _script="${_rest%% *}"
-          printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Do not use %s to run scripts. Ensure the script has a shebang (#!/usr/bin/env bash) and executable bit (chmod +x), then invoke it directly: ./%s"}}\n' "$_first_word" "$_script"
+          printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Do not use %s to run scripts. Ensure the script has a shebang (#!/usr/bin/env bash) and executable bit (chmod +x), then invoke it directly: %s/%s"}}\n' "$_first_word" "$PWD" "$_script"
           exit 0
         fi
         break
       else
-        printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Do not use %s to run scripts. Ensure the script has a shebang (#!/usr/bin/env bash) and executable bit (chmod +x), then invoke it directly: ./%s"}}\n' "$_first_word" "$_token"
+        printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Do not use %s to run scripts. Ensure the script has a shebang (#!/usr/bin/env bash) and executable bit (chmod +x), then invoke it directly: %s/%s"}}\n' "$_first_word" "$PWD" "$_token"
         exit 0
       fi
     done

--- a/skills/orchestrate/dispatch-subagents.md
+++ b/skills/orchestrate/dispatch-subagents.md
@@ -14,8 +14,8 @@ TASK_METADATA=$(jq -c --arg id "{TASK_ID}" '[.phases[].tasks[] | select(.id == $
 Then dispatch **all ready implementers in a single message** with multiple Agent tool calls — one per task. Splitting them across turns breaks parallelism and forces cache reloads for each agent.
 
 ```text
-Agent(name: "impl-{TASK_ID_LOWER}", subagent_type: "claude-caliper:task-implementer", model: "{TASK_IMPLEMENTER_MODEL}", prompt: "...")
-Agent(name: "impl-{TASK_ID_LOWER}", subagent_type: "claude-caliper:task-implementer", model: "{TASK_IMPLEMENTER_MODEL}", prompt: "...")
+Agent(name: "impl-{TASK_ID_LOWER}", subagent_type: "claude-caliper:task-implementer", mode: "acceptEdits", model: "{TASK_IMPLEMENTER_MODEL}", prompt: "...")
+Agent(name: "impl-{TASK_ID_LOWER}", subagent_type: "claude-caliper:task-implementer", mode: "acceptEdits", model: "{TASK_IMPLEMENTER_MODEL}", prompt: "...")
 ... (one per ready task)
 ```
 
@@ -35,6 +35,7 @@ Agent(
   name: "review-{TASK_ID_LOWER}",
   subagent_type: "claude-caliper:task-reviewer",
   model: "{TASK_REVIEWER_MODEL}",
+  mode: "acceptEdits",
   run_in_background: false,
   prompt: "<substitute task-reviewer-prompt.md with all {VARIABLES}>"
 )
@@ -45,7 +46,7 @@ Agent(
 
 ## Review Fix Cycle
 
-If fixes needed, dispatch a new `claude-caliper:task-implementer` agent into the same worktree to apply fixes — the lead coordinates, implementers touch code.
+If fixes needed, dispatch a new `claude-caliper:task-implementer` agent (with `mode: "acceptEdits"`) into the same worktree to apply fixes — the lead coordinates, implementers touch code.
 
 1. Read the reviewer's findings
 2. Dispatch a fix agent with the reviewer's findings and the task context, targeting the existing worktree path


### PR DESCRIPTION
## Summary
- Add `mode: "acceptEdits"` to implementer, reviewer, and fix-agent Agent calls in `dispatch-subagents.md` — missing this caused Edit/Write to be denied for every subagent dispatch in subagents-mode orchestration
- Fix shellcheck SC1091/SC2153 info notices in `pretooluse-deny-patterns.sh`

## Test plan
- Hook tests: 93 passed (0 failed) across `caliper-test_permission_request.sh` and `caliper-test_safe_commands.sh`
- Shellcheck clean on the modified hook script

Closes #206 (partially — retry-loop diagnosis rule is a separate skill change)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for denied script invocations to display full paths for better clarity.

* **Documentation**
  * Clarified agent configuration requirements for orchestration workflows, specifying `mode: "acceptEdits"` for task implementation and review agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->