### PR TITLE
feat(draft-plan): add self-review gate to fix plan-review editing-pass problem

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.37.0",
+      "version": "1.38.0",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.37.0",
+      "version": "1.38.0",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.37.0",
+      "version": "1.38.0",
 
       "source": "./",
       "author": {

--- a/agents/plan-drafter.md
+++ b/agents/plan-drafter.md
@@ -21,3 +21,7 @@ Template variables available in your invocation prompt:
 - `{REPO_PATH}` — repository root
 
 Use `{PLAN_DIR}` in place of `$PLAN_DIR` references from the SKILL.md.
+
+## Quality Bar
+
+Plan-review downstream is a gate, not an editing pass. Complete the Self-Review Gate step in SKILL.md before handoff — re-read every task file and fix Different Claude Test violations, unmeasurable `done_when`, vague steps, missing "why" in avoid sections, and artifact drift. If the reviewer has to apply more than one fix, the drafter did not do its job.

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -18,12 +18,13 @@ Write implementation plans assuming the executor has zero codebase context. Docu
 3. **Explore codebase** — Understand patterns, find exact file paths
 4. **Decide phasing** — Single vs multi-phase (see Phasing below)
 5. **Write plan.json** — Structured manifest with all task metadata
-6. **Write task .md files** — Prose for each task (Avoid+WHY, Steps)
+6. **Write task .md files** — Prose for each task (Avoid+WHY, Steps). Each step shows complete code, not verbs like "add X" or "handle Y". Avoid sections explain *why*, not just *what*.
 7. **Create completion.md stubs** — Empty files, one per phase
 8. **Run validate-plan --schema** — Fix any structural errors
 9. **Run validate-plan --render** — Generates plan.md deterministically
-10. **Skip** — plan artifacts are under `.claude/claude-caliper/` (gitignored), no commit needed
-11. **Hand off** — Report plan path to caller. Plan-review is dispatched by the design skill after draft-plan returns.
+10. **Self-review** — Re-read every task file and check against the Self-Review Gate below. Fix findings before handoff.
+11. **Skip** — plan artifacts are under `.claude/claude-caliper/` (gitignored), no commit needed
+12. **Hand off** — Report plan path to caller. Plan-review is dispatched by the design skill after draft-plan returns.
 
 ## Plan Structure
 
@@ -151,5 +152,23 @@ Write complete code in each step — not "add validation" or "implement the hand
 
 **Handoff notes:** The lead writes handoff sections to cross-phase task files between phases. Draft-plan doesn't write these.
 
-**Fresh Claude Test:** Could a fresh Claude with zero context execute this task without clarifying questions? Exact paths and measurable done_when = pass.
+## Self-Review Gate
+
+Before handoff, re-read every task file and the plan.json. The plan-reviewer downstream applies a 7-point checklist; catch the prose-level items here so review is pass/fail, not an editing pass. Goal at handoff: zero or one remaining issues.
+
+**Per task:**
+
+- **Different Claude Test** — Could a fresh Claude with zero context execute this unambiguously? No "the handler" or "the config" without a file path.
+- **Measurable `done_when`** — "4/4 tests pass" or "endpoint returns 200", not "auth works" or "feature complete".
+- **Complete code in steps** — Actual code, not "add validation" or "implement the handler".
+- **Avoid + WHY** — Every avoid section gives the reason, not just the prohibition.
+- **Artifact consistency** — Same file/function name everywhere. Every path in `plan.json` matches its prose references; every function referenced in prose matches its declaration.
+- **Verification is runnable** — The command exists in this codebase's tooling (npm vs yarn vs pnpm, pytest vs unittest).
+
+**Across the plan:**
+
+- **Design criteria map to tasks** — Each success criterion from the design doc is covered by at least one task's `done_when`. Missing criterion → add a task.
+- **Consolidation sweep** — Any task whose prose is shorter than its plan.json metadata should merge with a neighbor (see Task Consolidation).
+- **Complexity gates** — 8+ tasks single-phase or 7+ per phase → split.
+- **Interface-first ordering** — Tasks defining contracts precede tasks consuming them.
 


### PR DESCRIPTION
## Summary

Fixes #207. Plan-reviewer was finding 7 issues on a 6-task plan — meaning review became an editing pass rather than a pass/fail gate. Root cause: draft-plan's workflow ran `validate-plan --schema` (structural) and `--render`, then handed off. No prose-quality check ever ran on the drafter's own output.

- **skills/draft-plan/SKILL.md** — New step 10: Self-Review Gate before handoff. Drafter re-reads every task file against a checklist mirroring plan-reviewer's 7-point check, narrowed to items the drafter can fix pre-handoff: Different Claude Test, measurable `done_when`, complete code in steps, avoid+why, artifact consistency, runnable verification, design-criterion-to-task mapping, consolidation sweep, complexity gates, interface-first ordering. Step 6 gains inline quality reminders so quality bar travels with the workflow.
- **agents/plan-drafter.md** — Quality Bar section directs the drafter to complete Self-Review Gate before handoff, with the explicit framing: "If the reviewer has to apply more than one fix, the drafter did not do its job."
- **marketplace.json** — Version bump 1.37.0 → 1.38.0.

SKILL.md grew from ~850 to ~1230 words, well under the 1500-word soft cap.

## Test plan

- [ ] Run draft-plan on a multi-task design; confirm Self-Review Gate step fires before handoff
- [ ] Dispatch plan-review on the output; confirm issue count is 0–1 rather than the historical 5+

No behavior code changed, so no bash test scripts apply.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump: Updated claude-caliper, claude-caliper-workflow, and claude-caliper-tooling to 1.38.0

* **Documentation**
  * Enhanced plan drafting quality standards with stricter completion criteria
  * Added self-review checklist for task validation before handoff

<!-- end of auto-generated comment: release notes by coderabbit.ai -->