### PR TITLE
fix(validate-plan): use CWD branch in --check-workflow, not plan_dir branch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.38.0",
+      "version": "1.39.0",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.38.0",
+      "version": "1.39.0",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.38.0",
+      "version": "1.39.0",
 
       "source": "./",
       "author": {

--- a/bin/validate-plan
+++ b/bin/validate-plan
@@ -1316,7 +1316,7 @@ do_check_workflow() {
   }
 
   local current_branch
-  current_branch=$(git -C "$plan_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+  current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 
   if [[ "$current_branch" == integrate/* ]]; then
     for ((p=0; p<phase_count; p++)); do


### PR DESCRIPTION
## Summary
- `--check-workflow` was detecting the current branch via `git -C plan_dir`, but plan artifacts live in `.claude/` of the main checkout — so it always resolved to `main` regardless of which worktree invoked it
- Fixed by removing `-C plan_dir` so `git rev-parse --abbrev-ref HEAD` reads from the caller's CWD (the feature worktree)
- Bumped version to 1.39.0

## Test plan
- Reproducer: run `validate-plan --check-workflow` from a feature worktree where a PR exists — previously returned "no PR found for main → main/master", now correctly detects the worktree branch and finds the PR

Co-Authored-By: Claude <noreply@anthropic.com>