### PR TITLE
fix(hooks): consume design-approved sentinel even when target is a caliper file

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.39.0",
+      "version": "1.39.1",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.39.0",
+      "version": "1.39.1",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.39.0",
+      "version": "1.39.1",
 
       "source": "./",
       "author": {

--- a/hooks/permission-request-accept-edits.sh
+++ b/hooks/permission-request-accept-edits.sh
@@ -8,16 +8,9 @@ cwd=$(echo "$input" | jq -r '.cwd // empty')
 [[ -n "$cwd" ]] || exit 0
 
 file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
+is_caliper_file=0
 if [[ -n "$file_path" && "$file_path" == *"/.claude/claude-caliper/"* ]]; then
-  cat << 'HOOKJSON'
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PermissionRequest",
-    "decision": { "behavior": "allow" }
-  }
-}
-HOOKJSON
-  exit 0
+  is_caliper_file=1
 fi
 
 git_common_dir=$(git -C "$cwd" rev-parse --git-common-dir 2>/dev/null || true)
@@ -57,6 +50,18 @@ if [[ -n "$sentinel" ]]; then
         { "type": "setMode", "mode": "acceptEdits", "destination": "session" }
       ]
     }
+  }
+}
+HOOKJSON
+  exit 0
+fi
+
+if [[ $is_caliper_file -eq 1 ]]; then
+  cat << 'HOOKJSON'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PermissionRequest",
+    "decision": { "behavior": "allow" }
   }
 }
 HOOKJSON

--- a/tests/hooks/caliper-test_permission_request.sh
+++ b/tests/hooks/caliper-test_permission_request.sh
@@ -83,6 +83,22 @@ else
   ((PASS++)) || true
 fi
 
+echo "Test 5b: Sentinel + caliper file_path — sentinel wins (consume + setMode)"
+SENTINEL_DIR5B="$TMPDIR/sentinel-with-caliper-edit/.claude/claude-caliper/2026-04-27-topic"
+mkdir -p "$SENTINEL_DIR5B"
+touch "$SENTINEL_DIR5B/.design-approved"
+INPUT5B=$(jq -n --arg cwd "$TMPDIR/sentinel-with-caliper-edit" '{cwd: $cwd, tool_input: {file_path: ($cwd + "/.claude/claude-caliper/2026-04-27-topic/design-topic.md")}}')
+OUTPUT5B=$(echo "$INPUT5B" | bash "$HOOK" 2>/dev/null)
+assert_output_contains "sentinel + caliper edit returns allow" "$OUTPUT5B" '"behavior": "allow"'
+assert_output_contains "sentinel + caliper edit returns acceptEdits mode" "$OUTPUT5B" '"mode": "acceptEdits"'
+if [[ -f "$SENTINEL_DIR5B/.design-approved" ]]; then
+  echo "FAIL: sentinel not consumed when file_path is in caliper dir"
+  ((FAIL++)) || true
+else
+  echo "PASS: sentinel consumed even when file_path is in caliper dir"
+  ((PASS++)) || true
+fi
+
 ALLOW_HOOK="$REPO_ROOT/hooks/permission-request-allow.sh"
 
 run_allow() {


### PR DESCRIPTION
## Summary
- The accept-edits hook had a fast-path that auto-allowed Edit/Write inside `.claude/claude-caliper/` and `exit 0`'d before reaching the sentinel-check + `setMode` block.
- After design approval, the very first parent Edit is always writing the design doc at `.claude/claude-caliper/<topic>/design-<topic>.md`, so the fast-path swallowed the permission request and `.design-approved` was never consumed. Subsequent parent edits (plan.json, reviews.json) also live under `.claude/claude-caliper/`, so the session never flipped into acceptEdits.
- Reorder: run the sentinel check first. If a sentinel exists, emit `allow + setMode` unconditionally; only fall through to the caliper-file fast-path when no sentinel is found.
- Bumps marketplace version to 1.39.1.

## Test plan
- [x] `tests/hooks/caliper-test_permission_request.sh` — all 17 assertions pass, including new Test 5b that exercises the sentinel + caliper file_path overlap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Caliper plugins to version 1.39.1 across three components (Caliper, Workflow, and Tooling modules)

* **Improvements**
  * Enhanced file permission handling for editing workflows with improved sentinel-based authorization detection. Better permission decision-making for file edit requests in collaborative editing scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->