### PR TITLE
feat(orchestrate): create one TaskCreate entry per plan task

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.39.1",
+      "version": "1.39.2",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.39.1",
+      "version": "1.39.2",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.39.1",
+      "version": "1.39.2",
 
       "source": "./",
       "author": {

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -21,7 +21,7 @@ Execute plans via the configured execution mode. Phases run sequentially; task d
 
 ## Progress Tracking
 
-TaskCreate per phase: "Execute tasks ({N})", "Implementation review", "Create PR". Final: "Mark plan complete". Set `addBlockedBy`. Mark `in_progress` / `completed` as you go.
+TaskCreate one entry per task in plan.json (e.g. "Implement A1", "Implement A2", ...) plus per phase "Phase {LETTER}: implementation review", and final "Create PR" / "Mark plan complete". Set `addBlockedBy` to mirror task `depends_on` and phase ordering. Mark `in_progress` when you dispatch a task and `completed` when its task review passes — granular per-task tracking surfaces stuck tasks immediately rather than hiding them inside a phase-wide "Execute tasks" entry.
 
 ## Setup
 


### PR DESCRIPTION
## Summary

- Replace the per-phase \"Execute tasks ({N})\" rollup in `skills/orchestrate/SKILL.md` with one TaskCreate entry per plan task (e.g. \"Implement A1\", \"Implement A2\"). Phase-level entries cover only the wrap-up (\"Phase {LETTER}: implementation review\") plus the final \"Create PR\" / \"Mark plan complete\".
- Updated guidance: set `addBlockedBy` to mirror task `depends_on` and phase ordering; mark `in_progress` on dispatch and `completed` on review pass.
- Bumped marketplace version 1.39.1 → 1.39.2 across all three plugin entries since this changes orchestrate runtime behavior.

## Why

Granular per-task tracking surfaces stuck tasks immediately rather than hiding them inside a single phase-wide \"Execute tasks\" rollup.

## Test plan

- [x] Docs/text-only change to SKILL.md — no test suite covers this wording
- [x] `marketplace.json` still parses (jq read prior to edit)

Co-Authored-By: Claude <noreply@anthropic.com>