### PR TITLE
feat(orchestrate): serialize multi-phase execution at the merge boundary

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.40.0",
+      "version": "1.40.1",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.40.0",
+      "version": "1.40.1",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.40.0",
+      "version": "1.40.1",
 
       "source": "./",
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.39.2",
+      "version": "1.40.0",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.39.2",
+      "version": "1.40.0",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.39.2",
+      "version": "1.40.0",
 
       "source": "./",
       "author": {

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -52,7 +52,9 @@ Process phases in order (A, B, C...). For each phase:
 
 ### Prepare Phase
 
-1. Create phase worktree from integration branch (multi-phase) or use feature worktree (single-phase)
+1. Determine phase resumption state (multi-phase only — single-phase: use feature worktree, no resumption check needed). Phase status is the primary signal because squash-merge in step 6 typically deletes the phase branch ref, making `git merge-base --is-ancestor` unreliable.
+   - If phase status starts with "Complete": run `gh pr list --base integrate/<feature> --head phase-<letter> --state merged --json number --jq 'length'`. If non-zero, the phase is fully merged — skip to next phase. If zero (status Complete but PR not yet merged), skip directly to Phase Wrap-Up step 6, reusing any open PR or creating one if absent.
+   - Otherwise (status "Not Started" or "In Progress"): create phase worktree from integration branch and continue with the remaining numbered steps below (`validate-plan --check-base`, etc.).
 2. Re-validate base branch: `validate-plan --check-base "$PLAN_JSON"` (multi-phase only — ensures dispatch happens from integration worktree, not main)
 3. `PHASE_BASE_SHA=$(git rev-parse HEAD)` in worktree
 4. **Bootstrap dependencies** in the worktree. **See:** skills/design/dependency-bootstrap.md
@@ -77,7 +79,13 @@ After all tasks complete and branches merged:
 3. Append review changes to `${PHASE_DIR}/completion.md`
 4. Run phase criteria: `validate-plan --criteria "$PLAN_JSON" --phase {LETTER}`
 5. Update status: `validate-plan --update-status "$PLAN_JSON" --phase {LETTER} --status "Complete (YYYY-MM-DD)"`
-6. (Multi-phase) Create phase PR, external review gate, merge, clean up worktree
+6. (Multi-phase) Merge phase PR into integration branch — runs unconditionally for every phase including the last, regardless of `workflow` setting. The final integrate->main PR is created separately in "After All Phases".
+   a. `pr-create --base integrate/<feature>` to open the phase PR
+   b. `REVIEW_WAIT=$(caliper-settings get review_wait_minutes)`
+   c. If `$REVIEW_WAIT` == 0: invoke `pr-merge` directly. Else: poll `gh pr checks` then invoke `pr-review --automated-merge` (which invokes `pr-merge` on pass)
+   d. In the integration worktree (`.claude/worktrees/<feature>` — the orchestrate lead's primary CWD established at Setup; cd back if currently in a phase worktree): `git fetch origin && git reset --hard origin/integrate/<feature>` to fast-forward local integrate to the merged tip
+   e. Remove phase worktree: `git worktree remove .claude/worktrees/<feature>-phase-<letter>` (path/branch convention from pr-merge/SKILL.md:65-66)
+   f. Continuity: only Rule 4 deviations stop the loop. Review feedback is auto-fixed by `pr-review --automated-merge`.
 
 ## Review Loop Protocol
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -80,11 +80,11 @@ After all tasks complete and branches merged:
 4. Run phase criteria: `validate-plan --criteria "$PLAN_JSON" --phase {LETTER}`
 5. Update status: `validate-plan --update-status "$PLAN_JSON" --phase {LETTER} --status "Complete (YYYY-MM-DD)"`
 6. (Multi-phase) Merge phase PR into integration branch — runs unconditionally for every phase including the last, regardless of `workflow` setting. The final integrate->main PR is created separately in "After All Phases".
-   a. Open the phase PR: if one already exists (`gh pr view phase-<letter> --json url 2>/dev/null`), reuse it; otherwise run `pr-create --base integrate/<feature>`.
+   a. Open the phase PR: if one already exists and is open (`gh pr list --head phase-<letter> --state open --json url --jq '.[0].url'`), reuse it; otherwise run `pr-create --base integrate/<feature>`.
    b. `REVIEW_WAIT=$(caliper-settings get review_wait_minutes)`
    c. If `$REVIEW_WAIT` == 0: invoke `pr-merge` directly. Else: poll `gh pr checks` then invoke `pr-review --automated-merge` (which invokes `pr-merge` on pass)
-   d. In the integration worktree (`.claude/worktrees/<feature>` — the orchestrate lead's primary CWD established at Setup; cd back if currently in a phase worktree): `git fetch origin && git reset --hard origin/integrate/<feature>` to fast-forward local integrate to the merged tip
-   e. Remove phase worktree: `git worktree remove .claude/worktrees/<feature>-phase-<letter>` (path/branch convention from pr-merge/SKILL.md:65-66)
+   d. Return to the integration worktree (the orchestrate lead's primary CWD established at Setup) and fast-forward local integrate to the merged tip: `cd .claude/worktrees/<feature> && git fetch origin && git reset --hard origin/integrate/<feature>`
+   e. Remove phase worktree if it still exists (pr-merge typically removes it during cleanup; on resumption it may already be gone): `git worktree list --porcelain | grep -q "phase-<letter>$" && git worktree remove .claude/worktrees/<feature>-phase-<letter> --force || true`
    f. Continuity: only Rule 4 deviations stop the loop. Review feedback is auto-fixed by `pr-review --automated-merge`.
 
 ## Review Loop Protocol

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -80,7 +80,7 @@ After all tasks complete and branches merged:
 4. Run phase criteria: `validate-plan --criteria "$PLAN_JSON" --phase {LETTER}`
 5. Update status: `validate-plan --update-status "$PLAN_JSON" --phase {LETTER} --status "Complete (YYYY-MM-DD)"`
 6. (Multi-phase) Merge phase PR into integration branch — runs unconditionally for every phase including the last, regardless of `workflow` setting. The final integrate->main PR is created separately in "After All Phases".
-   a. `pr-create --base integrate/<feature>` to open the phase PR
+   a. Open the phase PR: if one already exists (`gh pr view phase-<letter> --json url 2>/dev/null`), reuse it; otherwise run `pr-create --base integrate/<feature>`.
    b. `REVIEW_WAIT=$(caliper-settings get review_wait_minutes)`
    c. If `$REVIEW_WAIT` == 0: invoke `pr-merge` directly. Else: poll `gh pr checks` then invoke `pr-review --automated-merge` (which invokes `pr-merge` on pass)
    d. In the integration worktree (`.claude/worktrees/<feature>` — the orchestrate lead's primary CWD established at Setup; cd back if currently in a phase worktree): `git fetch origin && git reset --hard origin/integrate/<feature>` to fast-forward local integrate to the merged tip


### PR DESCRIPTION
## Summary

- Multi-phase orchestrate now waits for each phase PR to merge into the integration branch before the next phase's worktree is created
- Replaces the one-line `Phase Wrap-Up` step 6 in `skills/orchestrate/SKILL.md` with an explicit per-phase merge cycle that reuses the single-phase pr-merge polling pattern (line 109 of the same file)
- Adds a resumption decision tree to `Prepare Phase` step 1 — uses phase status + `gh pr list --state merged` (survives squash-merge branch deletion, unlike `git merge-base --is-ancestor`)
- Step 6a is explicit about pr-create reuse: checks `gh pr view phase-<letter>` for an existing open PR before invoking pr-create

## Why

Previously orchestrate raced through all phases without waiting. Phase B's worktree was cut while phase A's PR was open, so phase B's branch carried phase A's commits as base. Phase B's PR against `integrate/<feature>` then showed phase A + phase B — re-litigating already-reviewed work and contradicting the SKILL.md's stated intent at the old line 80.

After this change, each phase PR's diff is naturally phase-only. Wall-clock cost is bounded at `review_wait_minutes` (default 5min, hard timeout) per phase. The final integrate→main PR keeps its full external review cycle unchanged.

## Test plan

- [x] All existing bash tests pass (1 unrelated pre-existing failure on main: `tests/validate-plan/caliper-test_check_workflow.sh::Test 9a` — stale test from PR #210)
- [x] `validate-design --check` passes on design doc
- [x] `validate-plan --schema` and `--criteria --plan` pass
- [x] Design review (opus) passed after 2 iterations
- [x] Plan review (sonnet) passed
- [x] Implementation review (opus) passed with one low-severity finding fixed inline (step 6a explicit reuse)
- [ ] Manual end-to-end verification on a real multi-phase plan (deferred per design doc — merge cycle reuses single-phase pr-merge primitives that are already exercised)

## Design doc

`.claude/claude-caliper/2026-04-27-serialize-phase-merges/design-serialize-phase-merges.md` (gitignored — paste on request)

Co-Authored-By: Claude <noreply@anthropic.com>