### PR TITLE
fix(hooks): drop Edit|Write PermissionRequest matcher pending upstream fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.40.1",
+      "version": "1.40.2",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.40.1",
+      "version": "1.40.2",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.40.1",
+      "version": "1.40.2",
 
       "source": "./",
       "author": {

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -10,7 +10,7 @@ Hook scripts and configuration for the claude-caliper plugin.
 | `lib-command-parser.sh` | Shared library: segment extraction, command word parsing, safe-commands loading |
 | `pretooluse-deny-patterns.sh` | PreToolUse(Bash): denies `bash -c`, `bash script.sh`, `$VAR` commands with feedback to Claude |
 | `permission-request-allow.sh` | PermissionRequest(Read/Glob/.../Bash): auto-allows safe tools/commands with session-scoped caching |
-| `permission-request-accept-edits.sh` | _Currently unwired_ — PermissionRequest(Edit/Write) hook for enabling acceptEdits mode after design approval. Disabled pending upstream fix to [anthropics/claude-code#12070](https://github.com/anthropics/claude-code/issues/12070), which causes Edit/Write to be denied in dispatched subagents even with `mode: "acceptEdits"`. |
+| `permission-request-accept-edits.sh` | _Currently unwired_ — PermissionRequest(Edit/Write) hook to enable acceptEdits mode after design approval. Disabled pending [anthropics/claude-code#12070](https://github.com/anthropics/claude-code/issues/12070); re-wire tracked in #215. |
 | `safe-commands.txt` | Bundled default safe command prefixes (~57 common dev tools) |
 
 ## Architecture

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -10,7 +10,7 @@ Hook scripts and configuration for the claude-caliper plugin.
 | `lib-command-parser.sh` | Shared library: segment extraction, command word parsing, safe-commands loading |
 | `pretooluse-deny-patterns.sh` | PreToolUse(Bash): denies `bash -c`, `bash script.sh`, `$VAR` commands with feedback to Claude |
 | `permission-request-allow.sh` | PermissionRequest(Read/Glob/.../Bash): auto-allows safe tools/commands with session-scoped caching |
-| `permission-request-accept-edits.sh` | PermissionRequest(Edit/Write): enables acceptEdits mode after design approval |
+| `permission-request-accept-edits.sh` | _Currently unwired_ — PermissionRequest(Edit/Write) hook for enabling acceptEdits mode after design approval. Disabled pending upstream fix to [anthropics/claude-code#12070](https://github.com/anthropics/claude-code/issues/12070), which causes Edit/Write to be denied in dispatched subagents even with `mode: "acceptEdits"`. |
 | `safe-commands.txt` | Bundled default safe command prefixes (~57 common dev tools) |
 
 ## Architecture

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -9,13 +9,6 @@
     }],
     "PermissionRequest": [
       {
-        "matcher": "Edit|Write",
-        "hooks": [{
-          "type": "command",
-          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-accept-edits.sh"
-        }]
-      },
-      {
         "matcher": "Read|Glob|Grep|Skill|WebFetch|WebSearch|ToolSearch|Bash",
         "hooks": [{
           "type": "command",


### PR DESCRIPTION
## Summary

- Removed the `Edit|Write` `PermissionRequest` matcher from `hooks/hooks.json`. The matcher was wired to `permission-request-accept-edits.sh`, which silently fell through for source-code edits in dispatched subagents — and per [anthropics/claude-code#12070](https://github.com/anthropics/claude-code/issues/12070) the silent fall-through is interpreted as a deny because the session's `acceptEdits` mode is not consulted after a hook participates in the decision.
- Real-world hit: in session `bc5b43fc-1c53-409a-9008-3982787f0a13`, a task-implementer dispatched with `mode: "acceptEdits"` got `Edit`/`Write` denied twice on `skills/orchestrate/SKILL.md` and worked around it via `python3` Bash. Lead's note: *"Edit/Write were denied even though I passed mode: acceptEdits."*
- Without the matcher, Edit/Write don't go through this hook at all, so dispatched subagents' `mode: "acceptEdits"` takes effect as intended.
- Re-enabling tracked in #215 (contains the exact diff to re-apply once upstream is fixed). The script, sentinel creation in `skills/design/SKILL.md`, and `tests/hooks/caliper-test_permission_request.sh` were intentionally left in place so re-wiring is a one-block addition.
- README updated to mark the script as currently unwired with a link to the upstream issue. Version bumped to 1.40.0.

## Test plan

- [x] `bash tests/hooks/caliper-test_permission_request.sh` — 17 passed (script still functions correctly for the sentinel and caliper-file branches; just no longer wired in `hooks.json`)
- [x] `bash tests/hooks/caliper-test_safe_commands.sh` — 79 passed
- [ ] Post-merge: verify in a real orchestrate run that a dispatched task-implementer can `Edit`/`Write` source files without denial.

Co-Authored-By: Claude <noreply@anthropic.com>