### PR TITLE
fix(design): add mode acceptEdits to plan-drafter dispatch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.40.2",
+      "version": "1.40.3",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.40.2",
+      "version": "1.40.3",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.40.2",
+      "version": "1.40.3",
 
       "source": "./",
       "author": {

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -142,6 +142,7 @@ Read the planner model: `PLANNER_MODEL=$(caliper-settings get planner_model)`
 Agent(
   subagent_type: "claude-caliper:plan-drafter",
   model: "$PLANNER_MODEL",
+  mode: "acceptEdits",
   prompt: "Read the design doc at .claude/claude-caliper/<folder>/design-<topic>.md and write
     an implementation plan.
 


### PR DESCRIPTION
## Summary

- Add `mode: "acceptEdits"` to the plan-drafter `Agent()` dispatch in `skills/design/SKILL.md`.
- Bump marketplace version 1.40.2 → 1.40.3 (3 entries).

## Why

PR #216 dropped the Edit|Write PermissionRequest matcher to work around Claude Code bug #12070. That hook was silently auto-approving plan-drafter Write calls even when the dispatching skill omitted `mode: "acceptEdits"`. Without the safety net, plan-drafter writes now hit the default deny — observed in session `8f560e71-b644-44e1-962b-a5da78bbaab2`: agent flailed through Bash heredoc, printf, and python3 fallbacks; corrupted `plan.json` with `{"hello":"world"}` probe content; hung 17 minutes on an ungranted Bash prompt.

Reviewer agents (design/plan/task/implementation) all have `tools: [Read, Grep, Glob, Bash]` — no Write/Edit. They emit a `review-summary` JSON block in their response and the parent writes `reviews.json`, so they don't need `acceptEdits`. Only plan-drafter and task-implementer have Write/Edit; task-implementer's canonical dispatch in `dispatch-subagents.md` already has the mode.

## Test plan

- [ ] Run a /design flow on a small feature, verify plan-drafter successfully writes plan.json without permission denials
- [ ] Verify plan.json is written to the correct path (no `{"hello":"world"}` debris)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.40.3 for Caliper, Caliper Workflow, and Caliper Tooling plugins.

* **Improvements**
  * Enhanced plan-drafting workflow with improved edit handling and acceptance capabilities during implementation planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->