### PR TITLE
fix(hooks): re-enable Edit|Write PermissionRequest hook with continue:true fallthrough

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.40.3",
+      "version": "1.40.4",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.40.3",
+      "version": "1.40.4",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.40.3",
+      "version": "1.40.4",
 
       "source": "./",
       "author": {

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,6 +14,13 @@
           "type": "command",
           "command": "${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-allow.sh"
         }]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [{
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-accept-edits.sh"
+        }]
       }
     ]
   }

--- a/hooks/permission-request-accept-edits.sh
+++ b/hooks/permission-request-accept-edits.sh
@@ -5,7 +5,10 @@ input=$(cat)
 
 cwd=$(echo "$input" | jq -r '.cwd // empty')
 
-[[ -n "$cwd" ]] || exit 0
+if [[ -z "$cwd" ]]; then
+  printf '{"continue": true}\n'
+  exit 0
+fi
 
 file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
 is_caliper_file=0
@@ -65,6 +68,11 @@ if [[ $is_caliper_file -eq 1 ]]; then
   }
 }
 HOOKJSON
+  exit 0
 fi
 
+# Bug #12070: silent exit on PermissionRequest is treated as deny and bypasses
+# acceptEdits mode. Output {"continue": true} so the harness defers to the
+# session's permission mode and configured allow rules.
+printf '{"continue": true}\n'
 exit 0

--- a/tests/hooks/caliper-test_permission_request.sh
+++ b/tests/hooks/caliper-test_permission_request.sh
@@ -42,14 +42,14 @@ assert_output_contains "sentinel exists returns allow behavior" "$OUTPUT1" '"beh
 assert_output_contains "sentinel exists returns acceptEdits mode" "$OUTPUT1" '"mode": "acceptEdits"'
 assert_output_contains "sentinel exists returns session destination" "$OUTPUT1" '"destination": "session"'
 
-echo "Test 1b: Sentinel consumed — second invocation produces no output"
+echo "Test 1b: Sentinel consumed — second invocation defers via continue:true"
 OUTPUT1B=$(echo "$INPUT1" | bash "$HOOK" 2>/dev/null)
-assert_output_empty "sentinel consumed, second call produces no output" "$OUTPUT1B"
+assert_output_contains "sentinel consumed, second call defers" "$OUTPUT1B" '"continue": true'
 
-echo "Test 2: No sentinel file produces no output (passthrough)"
+echo "Test 2: No sentinel file defers via continue:true (passthrough)"
 INPUT2=$(jq -n --arg cwd "$TMPDIR/no-sentinel-here" '{cwd: $cwd}')
 OUTPUT2=$(echo "$INPUT2" | bash "$HOOK" 2>/dev/null)
-assert_output_empty "missing sentinel produces no output" "$OUTPUT2"
+assert_output_contains "missing sentinel defers" "$OUTPUT2" '"continue": true'
 
 echo "Test 3: Worktree search path finds sentinel and consumes it"
 WORKTREE_SENTINEL="$TMPDIR/.claude/worktrees/my-branch/.claude/claude-caliper/2026-03-20-topic"
@@ -66,10 +66,10 @@ else
   ((PASS++)) || true
 fi
 
-echo "Test 4: Empty cwd produces no output"
+echo "Test 4: Empty cwd defers via continue:true"
 INPUT4=$(jq -n '{cwd: ""}')
 OUTPUT4=$(echo "$INPUT4" | bash "$HOOK" 2>/dev/null)
-assert_output_empty "empty cwd produces no output" "$OUTPUT4"
+assert_output_contains "empty cwd defers" "$OUTPUT4" '"continue": true'
 
 echo "Test 5: Auto-approve for .claude/claude-caliper/ file paths"
 INPUT5=$(jq -n --arg cwd "$TMPDIR" '{cwd: $cwd, tool_input: {file_path: "/some/project/.claude/claude-caliper/2026-03-20-topic/plan.md"}}')
@@ -96,6 +96,18 @@ if [[ -f "$SENTINEL_DIR5B/.design-approved" ]]; then
   ((FAIL++)) || true
 else
   echo "PASS: sentinel consumed even when file_path is in caliper dir"
+  ((PASS++)) || true
+fi
+
+echo "Test 5c: Non-caliper Edit/Write path defers via continue:true (bug #12070 — silent exit was treated as deny)"
+INPUT5C=$(jq -n --arg cwd "$TMPDIR" '{cwd: $cwd, tool_input: {file_path: "/some/project/src/foo.py"}}')
+OUTPUT5C=$(echo "$INPUT5C" | bash "$HOOK" 2>/dev/null)
+assert_output_contains "non-caliper file_path defers" "$OUTPUT5C" '"continue": true'
+if echo "$OUTPUT5C" | grep -qF '"behavior"'; then
+  echo "FAIL: non-caliper file should not emit a decision"
+  ((FAIL++)) || true
+else
+  echo "PASS: non-caliper file emits no decision"
   ((PASS++)) || true
 fi
 


### PR DESCRIPTION
## Summary

- Re-add `Edit|Write` matcher to `hooks/hooks.json`, pointing to the existing `permission-request-accept-edits.sh` script.
- Fix bug #12070 trigger by ensuring the script always emits explicit JSON. Non-caliper paths and missing-cwd cases now output `{"continue": true}` (canonical "no decision, defer to default") instead of silent `exit 0`.
- Update tests for new fallthrough behavior; add Test 5c covering the non-caliper Edit/Write path.
- Bump marketplace version 1.40.3 → 1.40.4.

## Why

PR #216 dropped the `Edit|Write` PermissionRequest matcher as a workaround for Claude Code bug #12070 (silent hook fallthrough is treated as a deny instead of a defer-to-mode). Without that matcher, subagents like plan-drafter that need to write to `.claude/claude-caliper/` plan dirs get denied even when correctly dispatched with `mode: "acceptEdits"`. Verified in session `8f560e71-b644-44e1-962b-a5da78bbaab2` retry #2: Write to `plan.json` returned the stock harness deny string with no hook involvement, killing plan-drafter twice in a row before the parent gave up and pivoted to writing files in main context.

The proper fix is `{"continue": true}` — the canonical signal for "I have no opinion on this request; defer to the next handler in the chain (next hook → permissionMode → permissions.allow/deny → interactive prompt)". That sidesteps bug #12070 entirely while still letting the caliper-path-specific allow logic at lines 59-67 fire for plan dir writes.

## Test plan

- [x] `tests/hooks/caliper-test_permission_request.sh` — 19/19 pass
- [x] `tests/hooks/caliper-test_safe_commands.sh` — pass
- [x] `tests/bin/caliper-test_bin_layout.sh` — pass
- [x] `tests/caliper-settings/caliper-test_caliper_settings.sh` — pass
- [ ] Re-run a /design flow on a feature, verify plan-drafter writes plan.json without permission denials
- [ ] Verify non-caliper Edit/Write calls still flow through normal acceptEdits / interactive permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)