### PR TITLE
chore(agents): remove maxTurns caps from agent frontmatter

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.40.4",
+      "version": "1.40.5",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.40.4",
+      "version": "1.40.5",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.40.4",
+      "version": "1.40.5",
 
       "source": "./",
       "author": {

--- a/agents/design-reviewer.md
+++ b/agents/design-reviewer.md
@@ -4,7 +4,6 @@ description: Reviews a design doc before planning begins
 model: inherit
 tools: [Read, Grep, Glob, Bash]
 memory: project
-maxTurns: 30
 effort: medium
 background: true
 ---

--- a/agents/implementation-reviewer.md
+++ b/agents/implementation-reviewer.md
@@ -4,7 +4,6 @@ description: Reviews an entire feature implementation for cross-task issues
 model: inherit
 tools: [Read, Grep, Glob, Bash]
 memory: project
-maxTurns: 30
 effort: medium
 background: true
 ---

--- a/agents/plan-drafter.md
+++ b/agents/plan-drafter.md
@@ -4,7 +4,6 @@ description: Writes implementation plans from design docs with structured plan.j
 model: inherit
 tools: [Read, Grep, Glob, Bash, Write, Edit]
 memory: project
-maxTurns: 50
 effort: high
 background: true
 ---

--- a/agents/plan-reviewer.md
+++ b/agents/plan-reviewer.md
@@ -4,7 +4,6 @@ description: Reviews an implementation plan before execution begins
 model: inherit
 tools: [Read, Grep, Glob, Bash]
 memory: project
-maxTurns: 30
 effort: medium
 background: true
 ---

--- a/agents/task-implementer.md
+++ b/agents/task-implementer.md
@@ -4,7 +4,6 @@ description: Implements a single task from an implementation plan using TDD
 model: inherit
 tools: [Read, Grep, Glob, Bash, Write, Edit]
 memory: none
-maxTurns: 80
 effort: high
 background: true
 ---

--- a/agents/task-reviewer.md
+++ b/agents/task-reviewer.md
@@ -4,7 +4,6 @@ description: Reviews a single task's implementation against its spec
 model: inherit
 tools: [Read, Grep, Glob, Bash]
 memory: none
-maxTurns: 30
 effort: medium
 background: true
 ---


### PR DESCRIPTION
## Summary
- Removes `maxTurns` from all 6 agent frontmatters (design-reviewer, plan-reviewer, task-reviewer, implementation-reviewer, plan-drafter, task-implementer)
- Caps silently truncate agents mid-task with no log trail; complex plans can legitimately exceed prior limits
- Bumps version to 1.40.5

## Test plan
- No tests reference `maxTurns` — change is purely agent frontmatter
- Verified all 6 agent files still have valid frontmatter

Co-Authored-By: Claude <noreply@anthropic.com>