### PR TITLE
fix(hooks): add date to safe-commands; phase-complete pattern auto-approves

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.40.5",
+      "version": "1.40.6",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.40.5",
+      "version": "1.40.6",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.40.5",
+      "version": "1.40.6",
 
       "source": "./",
       "author": {

--- a/hooks/safe-commands.txt
+++ b/hooks/safe-commands.txt
@@ -3,6 +3,7 @@ cat
 cd
 chmod
 cp
+date
 diff
 du
 echo

--- a/tests/hooks/caliper-test_safe_commands.sh
+++ b/tests/hooks/caliper-test_safe_commands.sh
@@ -389,6 +389,13 @@ cp "$REPO_ROOT/hooks/safe-commands.txt" "$SAFE56"
 OUT56=$(run_allow 'PLAN_DIR=/repo/.claude/caliper/plan; PLAN_JSON=$PLAN_DIR/plan.json; PHASE_DIR=$PLAN_DIR/phase-a; printf "## Review\n" >> "$PHASE_DIR/completion.md" && validate-plan --criteria "$PLAN_JSON" --plan && echo "DONE"' "$SAFE56")
 assert_output_contains "multi-level var refs with printf allowed" "$OUT56" '"behavior":"allow"'
 
+echo "Test 57: TS=\$(date ...); jq ...; validate-plan --update-status — phase-complete pattern"
+SAFE57="$TMPDIR_TEST/safe57.txt"
+cp "$REPO_ROOT/hooks/safe-commands.txt" "$SAFE57"
+# shellcheck disable=SC2016
+OUT57=$(run_allow 'PLAN_DIR=/repo/.claude/caliper/plan; PLAN_JSON=$PLAN_DIR/plan.json; TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ"); jq --arg ts "$TS" ". += [{\"verdict\":\"pass\",\"timestamp\":\$ts}]" "$PLAN_DIR/reviews.json" > "$PLAN_DIR/reviews.json.tmp" && mv "$PLAN_DIR/reviews.json.tmp" "$PLAN_DIR/reviews.json"; TODAY=$(date +"%Y-%m-%d"); validate-plan --update-status "$PLAN_JSON" --phase A --status "Complete ($TODAY)"' "$SAFE57")
+assert_output_contains "phase-complete pattern with date allowed" "$OUT57" '"behavior":"allow"'
+
 echo ""
 echo "=== PreToolUse Deny Tests ==="
 
@@ -396,12 +403,14 @@ echo "Test 27a: for-loop with bash \"\$t\" denied; message uses extracted loop v
 # shellcheck disable=SC2016
 OUT27A=$(run_deny 'for t in $(find tests -maxdepth 3 -name "*.sh" -executable); do echo "=== $t ==="; bash "$t" 2>&1 | tail -3 || echo "FAIL: $t"; done 2>&1 | tail -40')
 assert_output_contains_deny_with_reason "for-loop bash \$t denied" "$OUT27A" 'for-loop with bash'
+# shellcheck disable=SC2016
 assert_output_contains_deny_with_reason "for-loop message uses var t" "$OUT27A" '$t'
 
 echo "Test 27b: for-loop with result=\$(bash \"\$f\") denied; message uses loop var f"
 # shellcheck disable=SC2016
 OUT27B=$(run_deny 'for f in $(find tests -maxdepth 3 -name "*.sh" -executable); do result=$(bash "$f" 2>&1 | tail -1); if echo "$result" | grep -qi "fail"; then echo "FAILED: $f"; fi; done')
 assert_output_contains_deny_with_reason "for-loop result=\$(bash \$f) denied" "$OUT27B" 'for-loop with bash'
+# shellcheck disable=SC2016
 assert_output_contains_deny_with_reason "for-loop message uses var f" "$OUT27B" '$f'
 
 echo "Test 27: bash bin/validate-plan denied with guidance"


### PR DESCRIPTION
## Summary
- The phase-completion command pattern (`TS=$(date -u ...); jq ...; mv ...; TODAY=$(date ...); validate-plan --update-status`) was hitting user permission prompts because `date` was missing from `hooks/safe-commands.txt`. Every other word (jq, mv, echo, validate-plan, printf) was already safe — the lone unsafe `date` flipped `all_safe=0` in `permission-request-allow.sh` and the hook silently fell through.
- The "Unhandled node type: string" tree-sitter complaint shown in the prompt is cosmetic; the auto-approve gap is the actual cause.
- Adds `date` to safe-commands, plus a regression test (Test 57) covering the full phase-complete pattern. Bumps version 1.40.5 → 1.40.6.
- Also silences two pre-existing SC2016 warnings on Test 27a/27b literal substring assertions (`'$t'` / `'$f'`).

## Test plan
- `./tests/hooks/caliper-test_safe_commands.sh` → 86 passed, 0 failed (was 85; +1 for new Test 57)
- `shellcheck tests/hooks/caliper-test_safe_commands.sh` → clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Claude Caliper plugin suite to version 1.40.6

* **Tests**
  * Added test coverage for timestamp-based command orchestration workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->