### PR TITLE
fix(hooks): deny for-loop direct-exec patterns

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.40.7",
+      "version": "1.40.8",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.40.7",
+      "version": "1.40.8",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.40.7",
+      "version": "1.40.8",
 
       "source": "./",
       "author": {

--- a/hooks/pretooluse-deny-patterns.sh
+++ b/hooks/pretooluse-deny-patterns.sh
@@ -17,14 +17,31 @@ if [[ -z "$cmd" ]]; then
   exit 0
 fi
 
-# Fast path: deny for-loops with bash "$var" before extract_segments runs.
-# Must precede extract_segments — Claude Code's internal parser fires on complex
-# for-loops before PreToolUse hooks complete, producing confusing internal errors.
-if [[ "$cmd" == for\ * && "$cmd" == *'bash "$'* ]]; then
-  _loop_var="${cmd#for }"
-  _loop_var="${_loop_var%% *}"
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"for-loop with bash \"$%s\" detected. Invoke test scripts directly without bash: ./$%s"}}\n' "$_loop_var" "$_loop_var"
-  exit 0
+# Fast path: deny for-loops that trip Claude Code's tree-sitter parser before
+# extract_segments runs. The parser surfaces "Unhandled node type: string" /
+# "Contains for_statement" as a generic permission prompt without our deny
+# message — guide the agent to a non-loop pattern with a clear reason.
+# Match `for VAR in` anywhere in the command (loops can follow leading
+# variable assignments like FAIL=0; for f in ...).
+if [[ "$cmd" =~ (^|[^a-zA-Z0-9_])for[[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*)[[:space:]]+in[[:space:]] ]]; then
+  _loop_var="${BASH_REMATCH[2]}"
+
+  if [[ "$cmd" == *"bash \"\$$_loop_var\""* ]]; then
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"for-loop with bash \"$%s\" detected. Invoke test scripts directly without bash: ./$%s"}}\n' "$_loop_var" "$_loop_var"
+    exit 0
+  fi
+
+  case "$cmd" in
+    *"do \"\$$_loop_var\""*|\
+    *"; \"\$$_loop_var\""*|\
+    *"! \"\$$_loop_var\""*|\
+    *"&& \"\$$_loop_var\""*|\
+    *"|| \"\$$_loop_var\""*|\
+    *"then \"\$$_loop_var\""*)
+      printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"for-loop invoking \"$%s\" as a command trips Claude Code'"'"'s tree-sitter parser. Chain invocations with ; or && instead, or wrap them in a runner script."}}\n' "$_loop_var"
+      exit 0
+      ;;
+  esac
 fi
 
 extract_segments "$cmd"

--- a/hooks/pretooluse-deny-patterns.sh
+++ b/hooks/pretooluse-deny-patterns.sh
@@ -25,23 +25,19 @@ fi
 # variable assignments like FAIL=0; for f in ...).
 if [[ "$cmd" =~ (^|[^a-zA-Z0-9_])for[[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*)[[:space:]]+in[[:space:]] ]]; then
   _loop_var="${BASH_REMATCH[2]}"
+  _bash_pat='bash[[:space:]]+"\$'"$_loop_var"'"'
+  _kw_pat='(do|then)[[:space:]]+"\$'"$_loop_var"'"'
+  _sep_pat='(;|!|&&|\|\||\||&|\{)[[:space:]]*"\$'"$_loop_var"'"'
 
-  if [[ "$cmd" == *"bash \"\$$_loop_var\""* ]]; then
+  if [[ "$cmd" =~ $_bash_pat ]]; then
     printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"for-loop with bash \"$%s\" detected. Invoke test scripts directly without bash: ./$%s"}}\n' "$_loop_var" "$_loop_var"
     exit 0
   fi
 
-  case "$cmd" in
-    *"do \"\$$_loop_var\""*|\
-    *"; \"\$$_loop_var\""*|\
-    *"! \"\$$_loop_var\""*|\
-    *"&& \"\$$_loop_var\""*|\
-    *"|| \"\$$_loop_var\""*|\
-    *"then \"\$$_loop_var\""*)
-      printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"for-loop invoking \"$%s\" as a command trips Claude Code'"'"'s tree-sitter parser. Chain invocations with ; or && instead, or wrap them in a runner script."}}\n' "$_loop_var"
-      exit 0
-      ;;
-  esac
+  if [[ "$cmd" =~ $_kw_pat ]] || [[ "$cmd" =~ $_sep_pat ]]; then
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"for-loop invoking \"$%s\" as a command trips Claude Code'"'"'s tree-sitter parser. Chain invocations with ; or && instead, or wrap them in a runner script."}}\n' "$_loop_var"
+    exit 0
+  fi
 fi
 
 extract_segments "$cmd"

--- a/tests/hooks/caliper-test_safe_commands.sh
+++ b/tests/hooks/caliper-test_safe_commands.sh
@@ -413,6 +413,29 @@ assert_output_contains_deny_with_reason "for-loop result=\$(bash \$f) denied" "$
 # shellcheck disable=SC2016
 assert_output_contains_deny_with_reason "for-loop message uses var f" "$OUT27B" '$f'
 
+echo "Test 27c: for-loop with direct \"\$f\" exec after leading var assignment denied"
+# shellcheck disable=SC2016
+OUT27C=$(run_deny 'FAIL=0; for f in tests/validate-plan/caliper-test_*.sh tests/bin/caliper-test_*.sh; do [ -x "$f" ] || continue; if ! "$f" >/dev/null 2>&1; then echo "FAIL: $f"; FAIL=1; fi; done')
+assert_output_contains_deny_with_reason "for-loop direct \"\$f\" exec denied" "$OUT27C" 'tree-sitter parser'
+# shellcheck disable=SC2016
+assert_output_contains_deny_with_reason "Test 27c message uses var f" "$OUT27C" '$f'
+
+echo "Test 27d: for-loop with \"\$x\" at do position denied"
+# shellcheck disable=SC2016
+OUT27D=$(run_deny 'for x in *.sh; do "$x"; done')
+assert_output_contains_deny_with_reason "for-loop direct exec at do position denied" "$OUT27D" 'tree-sitter parser'
+
+echo "Test 27e: for-loop with quoted var only in echo (not command position) allowed"
+# shellcheck disable=SC2016
+OUT27E=$(run_deny 'for f in *.sh; do echo "$f"; done')
+if [[ -z "$OUT27E" ]]; then
+  echo "PASS: for-loop with echo \"\$f\" not denied"
+  ((PASS++)) || true
+else
+  echo "FAIL: for-loop with echo \"\$f\" should not be denied (got: $OUT27E)"
+  ((FAIL++)) || true
+fi
+
 echo "Test 27: bash bin/validate-plan denied with guidance"
 OUT27=$(run_deny "bash bin/validate-plan --schema plan.json")
 assert_output_contains_deny_with_reason "bash + script denied" "$OUT27" "Do not use"

--- a/tests/hooks/caliper-test_safe_commands.sh
+++ b/tests/hooks/caliper-test_safe_commands.sh
@@ -436,6 +436,16 @@ else
   ((FAIL++)) || true
 fi
 
+echo "Test 27f: for-loop with multi-space \"do  \$f\" denied (whitespace robustness)"
+# shellcheck disable=SC2016
+OUT27F=$(run_deny 'for f in *.sh; do  "$f"; done')
+assert_output_contains_deny_with_reason "for-loop multi-space do denied" "$OUT27F" 'tree-sitter parser'
+
+echo "Test 27g: for-loop with pipe \"| \$f\" denied (separator coverage)"
+# shellcheck disable=SC2016
+OUT27G=$(run_deny 'for f in *.sh; do cat input | "$f"; done')
+assert_output_contains_deny_with_reason "for-loop pipe-to-direct-exec denied" "$OUT27G" 'tree-sitter parser'
+
 echo "Test 27: bash bin/validate-plan denied with guidance"
 OUT27=$(run_deny "bash bin/validate-plan --schema plan.json")
 assert_output_contains_deny_with_reason "bash + script denied" "$OUT27" "Do not use"


### PR DESCRIPTION
## Summary
- Extends the deny hook fast-path to catch `for VAR in …; do "$VAR" …; done` direct-exec patterns. Previously the existing fast-path only matched `bash "$VAR"`, so direct invocation fell through to `extract_segments`, which folds the entire for-body into one segment and never inspects `"$VAR"`. Claude Code's internal tree-sitter parser then surfaced `Unhandled node type: string` as a generic permission prompt without our deny guidance.
- Loop-detection regex now matches `for VAR in` anywhere in the command (handles leading `FAIL=0;`-style assignments).
- Body check: `"$VAR"` at command position (after `do`/`;`/`!`/`&&`/`||`/`then`). Distinct deny message points at the tree-sitter parser cause and suggests sequential chaining or a runner script.
- Bumps marketplace version 1.40.6 → 1.40.7 across all three plugins.

## Test plan
- [x] 27c: full screenshot command (`FAIL=0; for f in tests/…; do [ -x "$f" ] || continue; if ! "$f" >/dev/null 2>&1; then …; fi; done`) → denied
- [x] 27d: `for x in *.sh; do "$x"; done` → denied
- [x] 27e (negative): `for f in *.sh; do echo "$f"; done` → not denied
- [x] 27a/27b (existing bash "$" patterns) → still denied
- [x] 90/90 hook suite passes
- [x] shellcheck clean (SC1091 pre-existing on unchanged `source` line)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced detection of unsafe bash command patterns, particularly in for-loop contexts.

* **Chores**
  * Updated plugin versions to 1.40.8 across all modules.

* **Tests**
  * Expanded test coverage for command safety validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->