### PR TITLE
fix(pr-skills): use bare git fetch origin to refresh remote-tracking refs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.40.8",
+      "version": "1.40.9",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.40.8",
+      "version": "1.40.9",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.40.8",
+      "version": "1.40.9",
 
       "source": "./",
       "author": {

--- a/skills/pr-create/SKILL.md
+++ b/skills/pr-create/SKILL.md
@@ -78,7 +78,7 @@ git fetch origin
 git rebase "origin/$REBASE_BASE"
 ```
 
-Use bare `git fetch origin` (no branch arg) so `refs/remotes/origin/$REBASE_BASE` actually advances. `git fetch origin <branch>` only updates `FETCH_HEAD`, leaving the remote-tracking ref stale — `git rebase origin/$REBASE_BASE` then rebases onto an outdated tip.
+Use bare `git fetch origin` (no branch arg) so `refs/remotes/origin/$REBASE_BASE` actually advances. `git fetch origin $REBASE_BASE` only updates `FETCH_HEAD`, leaving the remote-tracking ref stale — `git rebase origin/$REBASE_BASE` then rebases onto an outdated tip.
 
 If conflicts occur, resolve them and re-run tests before continuing.
 

--- a/skills/pr-create/SKILL.md
+++ b/skills/pr-create/SKILL.md
@@ -74,9 +74,11 @@ EOF
 
 ```bash
 REBASE_BASE="${BASE_BRANCH:-$DEFAULT_BRANCH}"
-git fetch origin "$REBASE_BASE"
+git fetch origin
 git rebase "origin/$REBASE_BASE"
 ```
+
+Use bare `git fetch origin` (no branch arg) so `refs/remotes/origin/$REBASE_BASE` actually advances. `git fetch origin <branch>` only updates `FETCH_HEAD`, leaving the remote-tracking ref stale — `git rebase origin/$REBASE_BASE` then rebases onto an outdated tip.
 
 If conflicts occur, resolve them and re-run tests before continuing.
 

--- a/skills/pr-merge/SKILL.md
+++ b/skills/pr-merge/SKILL.md
@@ -41,9 +41,11 @@ If branch protection requires human approval and the PR lacks it, tell the user 
 **Pre-merge rebase check:** Verify the PR branch is up-to-date with the base branch:
 
 ```bash
-git fetch origin $DEFAULT_BRANCH
+git fetch origin
 git merge-base --is-ancestor origin/$DEFAULT_BRANCH HEAD
 ```
+
+Use bare `git fetch origin` (no branch arg) so `refs/remotes/origin/$DEFAULT_BRANCH` actually advances. `git fetch origin $DEFAULT_BRANCH` only updates `FETCH_HEAD` — the `is-ancestor` check then compares against a stale ref and reports up-to-date when the branch is actually behind.
 
 If behind (non-zero exit): rebase onto default branch, resolve conflicts, run tests, push with `git push -u origin HEAD --force-with-lease`. Comment on PR with conflict resolution details. Complex conflicts → stop and ask user.
 

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -40,12 +40,14 @@ mode=$(caliper-settings get review_mode)
 ### Step 3: Rebase onto Base Branch
 
 ```bash
-git fetch origin $BASE_BRANCH
+git fetch origin
 if ! git merge-base --is-ancestor origin/$BASE_BRANCH HEAD; then
   git rebase origin/$BASE_BRANCH
   git push -u origin HEAD --force-with-lease
 fi
 ```
+
+Use bare `git fetch origin` (no branch arg) so the remote-tracking ref `refs/remotes/origin/$BASE_BRANCH` actually advances. `git fetch origin $BASE_BRANCH` only updates `FETCH_HEAD`, leaving `origin/$BASE_BRANCH` stale — which silently widens the reviewer's diff scope when other PRs merge during the session.
 
 If rebased, log it. If conflicts, stop and ask user. After force-push, only process comments posted *after* the push timestamp (or wait for fresh bot comments).
 


### PR DESCRIPTION
## Summary
- `git fetch origin <branch>` only updates `FETCH_HEAD`; `refs/remotes/origin/<branch>` does **not** advance. Downstream `git merge-base --is-ancestor`, `git rebase origin/<branch>`, and reviewer subagent diff scoping all read the remote-tracking ref, so the staleness silently widens or skips the rebase.
- Caught on PR #223: the pr-review reviewer flagged 3 out-of-scope findings against files from PR #222 (which had merged mid-session). After a bare `git fetch origin` and rebase, the diff narrowed to the actual change.
- Updated `pr-review`, `pr-merge`, and `pr-create` skills — each drops the explicit branch arg and adds a one-line note explaining why.
- Bumps marketplace version 1.40.8 → 1.40.9.

## Test plan
- [x] `grep "git fetch origin" skills/` shows only bare-form calls now
- [x] Each call site has a brief explanation following the code block