### PR TITLE
ci(claude-review): grant write perms so review can post comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary
- The Claude Code Review workflow's `GITHUB_TOKEN` had `pull-requests: read` and `issues: read`, so the review agent couldn't post findings.
- Run #25028898012 (PR #223) succeeded with 14 permission denials and `No buffered inline comments` — review produced no visible output.
- Bumps both scopes to `write` so future review runs can post comments.

## Test plan
- [ ] Confirm next PR triggers the workflow and a `claude[bot]` comment lands on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)