### PR TITLE
feat(design): plans live in main repo root, not worktree

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.40.9",
+      "version": "1.41.0",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.40.9",
+      "version": "1.41.0",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.40.9",
+      "version": "1.41.0",
 
       "source": "./",
       "author": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ docs/reviews/     — Codebase review reports
 .claude-plugin/   — Plugin manifest and marketplace config
 ```
 
-Plan artifacts (design docs, plan.json, task briefs) are created by the design/draft-plan skills under `.claude/claude-caliper/` and gitignored — they're transient working state, not permanent repo content.
+Plan artifacts (design docs, plan.json, task briefs) are created by the design/draft-plan skills under `$MAIN_ROOT/.claude/claude-caliper/` (main repo root, gitignored). They live in the main checkout — not the worktree — so they persist across worktree cleanup as a local record of design decisions and execution history.
 
 ## Testing
 

--- a/agents/plan-drafter.md
+++ b/agents/plan-drafter.md
@@ -15,7 +15,7 @@ Read `skills/draft-plan/SKILL.md` for the full planning methodology — workflow
 ## Agent-Specific Context
 
 Template variables available in your invocation prompt:
-- `{PLAN_DIR}` — absolute path to the plan directory (e.g., `.claude/claude-caliper/2026-04-02-feature/`)
+- `{PLAN_DIR}` — absolute path to the plan directory (e.g., `/Users/you/repo/.claude/claude-caliper/2026-04-02-feature/` — main repo root, not the worktree)
 - `{DESIGN_DOC}` — path to the approved design document
 - `{REPO_PATH}` — repository root
 

--- a/bin/validate-plan
+++ b/bin/validate-plan
@@ -453,7 +453,7 @@ do_schema() {
         fi
 
         local repo_root
-        repo_root=$(cd "$plan_dir" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null || echo "")
+        repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
         if [[ -n "$repo_root" ]]; then
           while IFS= read -r fc_path; do
             [[ -z "$fc_path" ]] && continue

--- a/skills/design-review/SKILL.md
+++ b/skills/design-review/SKILL.md
@@ -20,7 +20,7 @@ Dispatch a reviewer subagent to validate a design doc before planning. Catches s
 ## Dispatch
 
 Gather inputs:
-- **Design doc** — `.claude/claude-caliper/YYYY-MM-DD-topic/design-topic.md`
+- **Design doc** — absolute path under `$MAIN_ROOT/.claude/claude-caliper/YYYY-MM-DD-topic/design-topic.md` (main repo, not worktree)
 - **Repo root** — the worktree the design targets
 
 Dispatch with `model: "$DESIGN_REVIEWER_MODEL"` — review requires strong reasoning to catch blind spots the designer and user converged past.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -26,6 +26,15 @@ Complete in order:
 5. **Present design** — sections scaled to complexity, approval after each
 6. **Set up worktree** — `EnterWorktree` enables session-aware cleanup via `ExitWorktree`:
    - `EnterWorktree(name: "<feature>")` — creates `.claude/worktrees/<feature>` with branch `<feature>`
+   - Resolve persistent path variables (plans live in main repo, code work happens in worktree):
+
+     ```bash
+     MAIN_ROOT="$(git rev-parse --path-format=absolute --git-common-dir | sed 's|/\.git$||')"
+     PLAN_DIR="$MAIN_ROOT/.claude/claude-caliper/YYYY-MM-DD-<topic>"
+     WORKTREE="$MAIN_ROOT/.claude/worktrees/<feature>"
+     ```
+
+     `$PLAN_DIR` lives in the main repo (gitignored) so plan artifacts survive worktree cleanup. Use `$PLAN_DIR` and `$WORKTREE` — not relative paths — in every dispatch prompt and `jq` write below; subagents inherit worktree CWD and relative `.claude/claude-caliper/...` won't resolve.
    - Multi-phase: rename to integration branch: `git branch -m integrate/<feature>` — phase worktrees created by orchestrate as siblings
    - Single-phase: branch name `<feature>` is correct as-is; orchestrate works here directly, PRs to main
    1. Bootstrap dependencies per **See:** ./dependency-bootstrap.md
@@ -60,8 +69,8 @@ Complete in order:
 
     **Agent teams fallback:** If user picks "Agent teams", check `$CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`. If not `1`, use AskUserQuestion to explain: "Agent teams requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`. To enable: run `echo 'export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1' >> ~/.zshrc && source ~/.zshrc`, then restart Claude Code." Offer: "Continue with subagents" or "Stop (I'll restart with agent teams)". If they choose subagents, override the Q2 answer to `Subagents` before step 11 writes plan.json. If they stop, tell them the exact command to resume: `claude --continue` in the worktree directory.
 
-    On approval, create sentinel: `mkdir -p <plan-dir> && touch <plan-dir>/.design-approved`
-8. **Write design doc** — `.claude/claude-caliper/YYYY-MM-DD-<topic>/design-<topic>.md` (no commit — gitignored transient state)
+    On approval, create sentinel: `mkdir -p "$PLAN_DIR" && touch "$PLAN_DIR/.design-approved"`
+8. **Write design doc** — `$PLAN_DIR/design-<topic>.md` (no commit — gitignored transient state, lives in main repo)
 
    Before dispatching design-review, verify the doc satisfies this quality checklist (catches the most common reviewer findings on first pass):
    - Success criteria are behavioral outcomes, not implementation details ("users can log in" not "tests pass" or "middleware installed")
@@ -78,13 +87,13 @@ Complete in order:
     - Workflow: `Create PR` → `pr-create`, `Merge PR` → `pr-merge`, `Orchestrate only` → `orchestrate`, `Plan only` → `plan-only`
     - Exec mode: `Subagents` → `subagents`, `Agent teams` → `agent-teams`
 
-    Write both: `jq --arg w "<workflow>" --arg e "<exec-mode>" '.workflow = $w | .execution_mode = $e' plan.json > tmp && mv tmp plan.json`
+    Write both: `jq --arg w "<workflow>" --arg e "<exec-mode>" '.workflow = $w | .execution_mode = $e' "$PLAN_DIR/plan.json" > "$PLAN_DIR/plan.json.tmp" && mv "$PLAN_DIR/plan.json.tmp" "$PLAN_DIR/plan.json"`
 
     For multi-phase plans, also write the integration branch name:
-    `jq --arg ib "integrate/<feature>" '.integration_branch = $ib' plan.json > tmp && mv tmp plan.json`
+    `jq --arg ib "integrate/<feature>" '.integration_branch = $ib' "$PLAN_DIR/plan.json" > "$PLAN_DIR/plan.json.tmp" && mv "$PLAN_DIR/plan.json.tmp" "$PLAN_DIR/plan.json"`
 
     For **Create PR**, **Merge PR**, or **Orchestrate only**: invoke orchestrate.
-    For **Plan only**: run `validate-plan --check-workflow plan.json` to verify design-review and plan-review passed. Report the plan file path and stop.
+    For **Plan only**: run `validate-plan --check-workflow "$PLAN_DIR/plan.json"` to verify design-review and plan-review passed. Report the plan file path and stop.
 
 Read the design reviewer model: `DESIGN_REVIEWER_MODEL=$(caliper-settings get design_reviewer_model)`
 
@@ -92,9 +101,9 @@ Read the design reviewer model: `DESIGN_REVIEWER_MODEL=$(caliper-settings get de
 Agent(
   subagent_type: "claude-caliper:design-reviewer",
   model: "$DESIGN_REVIEWER_MODEL",
-  prompt: "Review the design doc at .claude/claude-caliper/<folder>/design-<topic>.md
+  prompt: "Review the design doc at $PLAN_DIR/design-<topic>.md
 
-    Codebase root: .claude/worktrees/<feature>"
+    Codebase root: $WORKTREE"
 )
 ```
 
@@ -125,9 +134,9 @@ After each reviewer dispatch, extract the `json review-summary` block from the r
    Agent(
      subagent_type: "claude-caliper:design-reviewer",
      model: "$DESIGN_REVIEWER_MODEL",
-     prompt: "Review the design doc at .claude/claude-caliper/<folder>/design-<topic>.md
+     prompt: "Review the design doc at $PLAN_DIR/design-<topic>.md
 
-       Codebase root: .claude/worktrees/<feature>
+       Codebase root: $WORKTREE
 
        ## Prior Issues
        <json array: id, severity, category, problem, fix, resolution, dismissal_reason?>"
@@ -143,11 +152,11 @@ Agent(
   subagent_type: "claude-caliper:plan-drafter",
   model: "$PLANNER_MODEL",
   mode: "acceptEdits",
-  prompt: "Read the design doc at .claude/claude-caliper/<folder>/design-<topic>.md and write
+  prompt: "Read the design doc at $PLAN_DIR/design-<topic>.md and write
     an implementation plan.
 
-    Working directory: .claude/worktrees/<feature>
-    Plan directory: .claude/claude-caliper/<folder>/"
+    Working directory: $WORKTREE
+    Plan directory: $PLAN_DIR/"
 )
 ```
 
@@ -159,10 +168,10 @@ Read the plan reviewer model: `PLAN_REVIEWER_MODEL=$(caliper-settings get plan_r
 Agent(
   subagent_type: "claude-caliper:plan-reviewer",
   model: "$PLAN_REVIEWER_MODEL",
-  prompt: "Review the implementation plan at .claude/claude-caliper/<folder>/plan.json
+  prompt: "Review the implementation plan at $PLAN_DIR/plan.json
 
-    Design doc: .claude/claude-caliper/<folder>/design-<topic>.md
-    Codebase root: .claude/worktrees/<feature>"
+    Design doc: $PLAN_DIR/design-<topic>.md
+    Codebase root: $WORKTREE"
 )
 ```
 

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -92,7 +92,7 @@ Complete in order:
     For multi-phase plans, also write the integration branch name:
     `jq --arg ib "integrate/<feature>" '.integration_branch = $ib' "$PLAN_DIR/plan.json" > "$PLAN_DIR/plan.json.tmp" && mv "$PLAN_DIR/plan.json.tmp" "$PLAN_DIR/plan.json"`
 
-    For **Create PR**, **Merge PR**, or **Orchestrate only**: invoke orchestrate.
+    For **Create PR**, **Merge PR**, or **Orchestrate only**: invoke orchestrate, passing `$PLAN_DIR/plan.json` as the absolute plan path (orchestrate's CWD is the worktree, where plan.json does not exist).
     For **Plan only**: run `validate-plan --check-workflow "$PLAN_DIR/plan.json"` to verify design-review and plan-review passed. Report the plan file path and stop.
 
 Read the design reviewer model: `DESIGN_REVIEWER_MODEL=$(caliper-settings get design_reviewer_model)`

--- a/skills/design/design-spec.md
+++ b/skills/design/design-spec.md
@@ -16,10 +16,10 @@ The plan-drafter reads the design doc and nothing else. Every assumption, file r
 ## File Convention
 
 ```text
-.claude/claude-caliper/YYYY-MM-DD-<topic>/design-<topic>.md
+$MAIN_ROOT/.claude/claude-caliper/YYYY-MM-DD-<topic>/design-<topic>.md
 ```
 
-Example: `.claude/claude-caliper/2026-04-11-auth-redesign/design-auth-redesign.md`
+Where `$MAIN_ROOT` is the main repo root (resolved from `git rev-parse --git-common-dir`). Plans live in the main repo so they survive worktree cleanup. Example: `/Users/you/repo/.claude/claude-caliper/2026-04-11-auth-redesign/design-auth-redesign.md`
 
 ---
 

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -9,7 +9,7 @@ description: Use when you have a spec or requirements for a multi-step task, bef
 
 Write implementation plans assuming the executor has zero codebase context. Document everything: which files to touch, exact code, how to test, what to avoid and why.
 
-**Save to:** `.claude/claude-caliper/YYYY-MM-DD-<topic>/` directory
+**Save to:** the absolute `$PLAN_DIR` injected by the dispatcher (resolves to `$MAIN_ROOT/.claude/claude-caliper/YYYY-MM-DD-<topic>/` in the main repo, not the worktree). Plans are gitignored but persist across worktree cleanup.
 
 ## Workflow
 
@@ -23,7 +23,7 @@ Write implementation plans assuming the executor has zero codebase context. Docu
 8. **Run validate-plan --schema** — Fix any structural errors
 9. **Run validate-plan --render** — Generates plan.md deterministically
 10. **Self-review** — Re-read every task file and check against the Self-Review Gate below. Fix findings before handoff.
-11. **Skip** — plan artifacts are under `.claude/claude-caliper/` (gitignored), no commit needed
+11. **Skip** — plan artifacts are under `$MAIN_ROOT/.claude/claude-caliper/` (main repo root, gitignored), no commit needed
 12. **Hand off** — Report plan path to caller. Plan-review is dispatched by the design skill after draft-plan returns.
 
 ## Plan Structure

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -27,7 +27,7 @@ TaskCreate one entry per task in plan.json (e.g. "Implement A1", "Implement A2",
 
 Before first phase:
 - Resolve absolute path: `PLAN_JSON=$(realpath plan.json)` and `PLAN_DIR=$(dirname "$PLAN_JSON")`
-  Plan artifacts live under `.claude/claude-caliper/` (gitignored). Phase worktrees won't have these files, so all plan.json references must use the absolute `$PLAN_JSON` path — it points to the integration worktree where the plan was created.
+  Plan artifacts live in the main repo at `$MAIN_ROOT/.claude/claude-caliper/` (gitignored, decoupled from worktree lifetime so they survive cleanup). Phase worktrees don't have these files, so all references must use the absolute `$PLAN_JSON` / `$PLAN_DIR` paths.
 - Read workflow: `WORKFLOW=$(jq -r '.workflow' "$PLAN_JSON")`
 - Read execution mode: `EXEC_MODE=$(jq -r '.execution_mode' "$PLAN_JSON")`
 Note: `workflow` and `execution_mode` are read from plan.json (set by the design skill based on user selection and caliper-settings defaults), not from caliper-settings at runtime. This avoids two sources of truth — the plan is the single source once created.

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -26,8 +26,15 @@ TaskCreate one entry per task in plan.json (e.g. "Implement A1", "Implement A2",
 ## Setup
 
 Before first phase:
-- Resolve absolute path: `PLAN_JSON=$(realpath plan.json)` and `PLAN_DIR=$(dirname "$PLAN_JSON")`
-  Plan artifacts live in the main repo at `$MAIN_ROOT/.claude/claude-caliper/` (gitignored, decoupled from worktree lifetime so they survive cleanup). Phase worktrees don't have these files, so all references must use the absolute `$PLAN_JSON` / `$PLAN_DIR` paths.
+- Resolve main repo and plan paths. Plan artifacts live in the main repo at `$MAIN_ROOT/.claude/claude-caliper/` (gitignored, decoupled from worktree lifetime so they survive cleanup) — they are NOT in the worktree CWD, so `realpath plan.json` from the worktree will fail.
+
+  ```bash
+  MAIN_ROOT="$(git rev-parse --path-format=absolute --git-common-dir | sed 's|/\.git$||')"
+  PLAN_JSON="$(realpath -- "<absolute-path-passed-by-caller>")"
+  PLAN_DIR="$(dirname "$PLAN_JSON")"
+  ```
+
+  The caller (design skill or user) supplies the absolute plan.json path — typically `$MAIN_ROOT/.claude/claude-caliper/<folder>/plan.json`. All references downstream must use the absolute `$PLAN_JSON` / `$PLAN_DIR` paths since phase worktrees don't have these files.
 - Read workflow: `WORKFLOW=$(jq -r '.workflow' "$PLAN_JSON")`
 - Read execution mode: `EXEC_MODE=$(jq -r '.execution_mode' "$PLAN_JSON")`
 Note: `workflow` and `execution_mode` are read from plan.json (set by the design skill based on user selection and caliper-settings defaults), not from caliper-settings at runtime. This avoids two sources of truth — the plan is the single source once created.

--- a/skills/plan-review/SKILL.md
+++ b/skills/plan-review/SKILL.md
@@ -26,7 +26,7 @@ Two-stage review:
 **Stage 2: Prose + design review** — If schema passes, dispatch reviewer subagent.
 
 Gather inputs:
-- **Plan directory** — `.claude/claude-caliper/YYYY-MM-DD-topic/` (containing plan.json + task .md files)
+- **Plan directory** — absolute path under `$MAIN_ROOT/.claude/claude-caliper/YYYY-MM-DD-topic/` (containing plan.json + task .md files; main repo, not worktree)
 - **Design doc** — if one exists (or "None")
 - **Repo root** — the worktree the plan targets
 

--- a/tests/validate-plan/caliper-test_e2e.sh
+++ b/tests/validate-plan/caliper-test_e2e.sh
@@ -33,6 +33,11 @@ assert_eq() {
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 cp -r "$FIXTURES/valid-plan/"* "$TMPDIR/"
+( cd "$TMPDIR" && git init -q 2>/dev/null ) || true
+mkdir -p "$TMPDIR/src" "$TMPDIR/tests"
+touch "$TMPDIR/src/core.ts" "$TMPDIR/src/validate.ts" "$TMPDIR/src/dashboard.ts"
+touch "$TMPDIR/tests/core.test.ts" "$TMPDIR/tests/validate.test.ts" "$TMPDIR/tests/dashboard.test.ts"
+cd "$TMPDIR"
 
 check "initial schema validation" "$VALIDATE" --schema "$TMPDIR/plan.json"
 

--- a/tests/validate-plan/caliper-test_status_consistency.sh
+++ b/tests/validate-plan/caliper-test_status_consistency.sh
@@ -40,10 +40,15 @@ setup_valid_plan() {
   rm -rf "${dir:?}/"*
   cp -r "$FIXTURES/valid-plan/"* "$dir/"
   cp "$FIXTURES/valid-plan/plan.json" "$dir/plan.json"
+  ( cd "$dir" && git init -q 2>/dev/null ) || true
+  mkdir -p "$dir/src" "$dir/tests"
+  touch "$dir/src/core.ts" "$dir/src/validate.ts" "$dir/src/dashboard.ts"
+  touch "$dir/tests/core.test.ts" "$dir/tests/validate.test.ts" "$dir/tests/dashboard.test.ts"
 }
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
+cd "$TMPDIR"
 
 echo "Test 1: Phase marked Complete with all tasks complete passes"
 setup_valid_plan "$TMPDIR"
@@ -118,10 +123,11 @@ assert_pass "files.create exist on disk for complete task" \
 
 echo "Test 9: Files listed in files.create missing on disk when task is complete fails"
 setup_valid_plan "$TMPDIR"
-jq '.phases[0].tasks[0].status = "complete"' "$TMPDIR/plan.json" > "$TMPDIR/plan2.json" && mv "$TMPDIR/plan2.json" "$TMPDIR/plan.json"
+jq '.status = "In Development" | .phases[0].status = "In Progress" | .phases[0].tasks[0].status = "complete"' "$TMPDIR/plan.json" > "$TMPDIR/plan2.json" && mv "$TMPDIR/plan2.json" "$TMPDIR/plan.json"
 mkdir -p "$TMPDIR/phase-a"
 echo "# A1 Completion" > "$TMPDIR/phase-a/a1-completion.md"
-git -C "$TMPDIR" init -q 2>/dev/null || true
+echo '[{"type":"task-review","scope":"A1","verdict":"pass","remaining":0}]' > "$TMPDIR/reviews.json"
+rm -f "$TMPDIR/src/core.ts"
 assert_fail "files.create missing on disk for complete task" "missing_created_file" \
   "$VALIDATE" --schema "$TMPDIR/plan.json"
 


### PR DESCRIPTION
## Summary

- Design skill now resolves \`MAIN_ROOT\` after \`EnterWorktree\` and writes plan artifacts (design doc, plan.json, task .md files, reviews.json, completion notes) to \`\$MAIN_ROOT/.claude/claude-caliper/<folder>/\` instead of relative paths that land inside the worktree. Plans survive \`git worktree remove\` as a persistent local record per repo.
- Documentation aligned across \`skills/design\`, \`skills/draft-plan\`, \`skills/plan-review\`, \`skills/design-review\`, \`skills/orchestrate\`, \`agents/plan-drafter.md\`, \`CLAUDE.md\` so dispatched subagents see absolute \`\$PLAN_DIR\` / \`\$WORKTREE\` paths instead of relative examples that would break under the new model.
- Bundled fix: \`bin/validate-plan\` line 456 dropped \`cd \"\$plan_dir\"\` from git resolution — \`files.create\` existence checks must resolve against the worktree CWD (where files exist), not main repo (where plan_dir now lives).

## Test plan

- [x] All caliper-* test suites green (validate-plan: 33+17+10+11+24+23+11+9+6+6+5+10+2+11+8 across 15 suites; hooks: 19+92; validate-design: 10; bin: 7; caliper-settings: 78)
- [x] Test fixtures updated for new CWD-based file resolution (e2e, status_consistency now \`git init\` TMPDIR + materialize \`files.create\` + \`cd \"\$TMPDIR\"\`)
- [x] Implementation review: zero findings, internal consistency verified across all dispatch prompts and doc references
- [x] Version bumped 1.40.9 → 1.41.0 across all three plugin packages in marketplace.json

Co-Authored-By: Claude <noreply@anthropic.com>