### PR TITLE
fix(hooks): handle bash array-literal assignments in command parser

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.41.0",
+      "version": "1.41.1",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.41.0",
+      "version": "1.41.1",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.41.0",
+      "version": "1.41.1",
 
       "source": "./",
       "author": {

--- a/hooks/lib-command-parser.sh
+++ b/hooks/lib-command-parser.sh
@@ -125,6 +125,7 @@ extract_command_words_from_segment() {
   local var_subshell_re='^[A-Za-z_][A-Za-z0-9_]*="?\$\((.+)\)"?$'
   local var_literal_re='^[A-Za-z_][A-Za-z0-9_]*=[^$]'
   local var_ref_re='^[A-Za-z_][A-Za-z0-9_]*=\$'
+  local array_assign_re='^[A-Za-z_][A-Za-z0-9_]*=\('
   if [[ "$seg" =~ $pure_subshell_re ]]; then
     local inner="${BASH_REMATCH[1]}"
     inner="${inner#"${inner%%[![:space:]]*}"}"
@@ -135,6 +136,8 @@ extract_command_words_from_segment() {
     outer_cmd="${inner%% *}"
   elif [[ "$seg" =~ $var_ref_re ]]; then
     : # VAR=$other/path — variable reference assignment, not a command
+  elif [[ "$seg" =~ $array_assign_re ]]; then
+    : # VAR=(item item ...) — bash array literal, not a command
   elif [[ "$seg" =~ $var_literal_re ]]; then
     local current="$seg"
     outer_cmd=""

--- a/tests/hooks/caliper-test_safe_commands.sh
+++ b/tests/hooks/caliper-test_safe_commands.sh
@@ -396,6 +396,21 @@ cp "$REPO_ROOT/hooks/safe-commands.txt" "$SAFE57"
 OUT57=$(run_allow 'PLAN_DIR=/repo/.claude/caliper/plan; PLAN_JSON=$PLAN_DIR/plan.json; TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ"); jq --arg ts "$TS" ". += [{\"verdict\":\"pass\",\"timestamp\":\$ts}]" "$PLAN_DIR/reviews.json" > "$PLAN_DIR/reviews.json.tmp" && mv "$PLAN_DIR/reviews.json.tmp" "$PLAN_DIR/reviews.json"; TODAY=$(date +"%Y-%m-%d"); validate-plan --update-status "$PLAN_JSON" --phase A --status "Complete ($TODAY)"' "$SAFE57")
 assert_output_contains "phase-complete pattern with date allowed" "$OUT57" '"behavior":"allow"'
 
+echo "Test 58: VAR=(...) bash array literal allowed when body cmds are safe"
+SAFE58="$TMPDIR_TEST/safe58.txt"
+cp "$REPO_ROOT/hooks/safe-commands.txt" "$SAFE58"
+# shellcheck disable=SC2016
+OUT58=$(run_allow 'PLAN_DIR=/repo/plan
+FILES=(
+  "$PLAN_DIR/a.md"
+  "$PLAN_DIR/b.md"
+)
+for f in "${FILES[@]}"; do
+  sed -i "" -e "s|x|y|g" "$f"
+done
+echo "done"' "$SAFE58")
+assert_output_contains "array literal + safe loop body allowed" "$OUT58" '"behavior":"allow"'
+
 echo ""
 echo "=== PreToolUse Deny Tests ==="
 


### PR DESCRIPTION
## Summary
- `VAR=(...)` array assignments fell through to `var_literal_re`, which extracted the first array element as a fake command word — blocking auto-allow for otherwise-safe scripts that iterate `"${VAR[@]}"`
- Added `array_assign_re` case before `var_literal_re` to skip array assignments (same shape as existing `var_ref_re` skip for `VAR=$other`)
- Bumps version to 1.41.1

## Repro (the prompt that surfaced it)
```bash
PLAN_DIR=/some/path
FILES=(
  "$PLAN_DIR/a.md"
  "$PLAN_DIR/b.md"
)
for f in "${FILES[@]}"; do
  sed -i '' -e 's|x|y|g' "$f"
done
```
All inner commands are safe (`sed`, `for`, `do`, `done`), but `extract_command_words_from_segment` was emitting `a.md"` from the array body, dropping `all_safe` to 0.

## Test plan
- [x] New regression test (Test 58) — `VAR=(...)` + safe loop body → `behavior:allow`
- [x] All 93 existing safe-commands tests pass
- [x] Manual trace: real-world 19-segment command from the original prompt now extracts only safe words

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated marketplace plugin versions to 1.41.1 for caliper, caliper-workflow, and caliper-tooling

* **Bug Fixes**
  * Fixed bash command parsing to correctly handle array literal assignments and prevent array contents from being misinterpreted as executable commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->