### PR TITLE
feat: guard plan.md from edits + add --add-file/--remove-file CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,10 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-
-
-      "version": "1.41.3",
-
+      "version": "1.42.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -36,10 +33,7 @@
     {
       "name": "claude-caliper-workflow",
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
-
-
-      "version": "1.41.3",
-
+      "version": "1.42.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -62,10 +56,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit and skill evaluation",
-
-
-      "version": "1.41.3",
-
+      "version": "1.42.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/bin/validate-plan
+++ b/bin/validate-plan
@@ -24,6 +24,8 @@ Usage:
   validate-plan --check-deps <plan.json> --task <ID>
   validate-plan --check-workflow <plan.json>
   validate-plan --add-dep <plan.json> --task <DOWNSTREAM_ID> --depends-on <SOURCE_ID>
+  validate-plan --add-file <plan.json> --task <ID> --kind <create|modify|test> --path <FILE>
+  validate-plan --remove-file <plan.json> --task <ID> --kind <create|modify|test> --path <FILE>
   validate-plan --check-handoffs <plan.json> --phase <LETTER>
 
   Valid types:  design-review, plan-review, task-review, impl-review
@@ -1452,6 +1454,147 @@ do_add_dep() {
   trap - EXIT
 }
 
+do_add_file() {
+  local plan_json="$1" task_id="$2" kind="$3" path="$4"
+
+  case "$kind" in
+    create|modify|test) ;;
+    *)
+      echo "ERROR: invalid_kind: '$kind' (expected: create, modify, or test)" >&2
+      exit 1
+      ;;
+  esac
+
+  lock_plan "$plan_json"
+  trap 'unlock_plan "'"$plan_json"'"' EXIT
+
+  local task_letter task_status
+  task_letter=$(jq -r --arg id "$task_id" '
+    [.phases[] | select(.tasks[] | .id == $id)][0] | .letter // ""
+  ' "$plan_json")
+  if [[ -z "$task_letter" ]]; then
+    unlock_plan "$plan_json"; trap - EXIT
+    echo "ERROR: task_not_found: '$task_id'" >&2
+    exit 1
+  fi
+
+  task_status=$(jq -r --arg id "$task_id" '.phases[].tasks[] | select(.id == $id) | .status' "$plan_json")
+  if [[ "$task_status" == "complete" || "$task_status" == "skipped" ]]; then
+    unlock_plan "$plan_json"; trap - EXIT
+    echo "ERROR: cannot_modify_files: task '$task_id' is '$task_status' — files can only be added to pending or in_progress tasks" >&2
+    exit 1
+  fi
+
+  local cross_kind
+  cross_kind=$(jq -r --arg id "$task_id" --arg kind "$kind" --arg p "$path" '
+    .phases[].tasks[] | select(.id == $id) |
+    [
+      (if $kind != "create" then (.files.create // [])[] else empty end),
+      (if $kind != "modify" then (.files.modify // [])[] else empty end),
+      (if $kind != "test"   then (.files.test   // [])[] else empty end)
+    ] | map(select(. == $p)) | first // ""
+  ' "$plan_json")
+  if [[ -n "$cross_kind" ]]; then
+    unlock_plan "$plan_json"; trap - EXIT
+    echo "ERROR: cross_kind_conflict: path '$path' already appears in another kind on task '$task_id'" >&2
+    exit 1
+  fi
+
+  local already
+  already=$(jq -r --arg id "$task_id" --arg kind "$kind" --arg p "$path" '
+    .phases[].tasks[] | select(.id == $id) | (.files[$kind] // []) | index($p) // ""
+  ' "$plan_json")
+  if [[ -n "$already" ]]; then
+    unlock_plan "$plan_json"; trap - EXIT
+    exit 0
+  fi
+
+  local phase_owner
+  phase_owner=$(jq -r --arg letter "$task_letter" --arg id "$task_id" --arg p "$path" '
+    .phases[] | select(.letter == $letter) | .tasks[] |
+    select(.id != $id) |
+    select(((.files.create // []) + (.files.modify // []) + (.files.test // [])) | index($p)) |
+    .id
+  ' "$plan_json" | head -n 1)
+  if [[ -n "$phase_owner" ]]; then
+    unlock_plan "$plan_json"; trap - EXIT
+    echo "ERROR: fileset_overlap_add: path '$path' already claimed by task '$phase_owner' in phase $task_letter" >&2
+    exit 1
+  fi
+
+  if [[ "$kind" == "create" ]]; then
+    local global_owner
+    global_owner=$(jq -r --arg id "$task_id" --arg p "$path" '
+      .phases[].tasks[] | select(.id != $id) |
+      select((.files.create // []) | index($p)) | .id
+    ' "$plan_json" | head -n 1)
+    if [[ -n "$global_owner" ]]; then
+      unlock_plan "$plan_json"; trap - EXIT
+      echo "ERROR: duplicate_create_path_add: path '$path' already in create[] of task '$global_owner'" >&2
+      exit 1
+    fi
+  fi
+
+  local tmp="${plan_json}.tmp.$$"
+  jq --arg id "$task_id" --arg kind "$kind" --arg p "$path" '
+    (.phases[].tasks[] | select(.id == $id) | .files[$kind]) |= ((. // []) + [$p])
+  ' "$plan_json" > "$tmp" || { rm -f "$tmp"; unlock_plan "$plan_json"; trap - EXIT; echo "ERROR: jq update failed" >&2; exit 1; }
+  mv "$tmp" "$plan_json" || { rm -f "$tmp"; unlock_plan "$plan_json"; trap - EXIT; echo "ERROR: failed to write plan.json" >&2; exit 1; }
+  do_render "$plan_json"
+  unlock_plan "$plan_json"
+  trap - EXIT
+}
+
+do_remove_file() {
+  local plan_json="$1" task_id="$2" kind="$3" path="$4"
+
+  case "$kind" in
+    create|modify|test) ;;
+    *)
+      echo "ERROR: invalid_kind: '$kind' (expected: create, modify, or test)" >&2
+      exit 1
+      ;;
+  esac
+
+  lock_plan "$plan_json"
+  trap 'unlock_plan "'"$plan_json"'"' EXIT
+
+  local task_found task_status
+  task_found=$(jq -r --arg id "$task_id" '
+    [.phases[] | select(.tasks[] | .id == $id)] | length
+  ' "$plan_json")
+  if [[ "$task_found" -eq 0 ]]; then
+    unlock_plan "$plan_json"; trap - EXIT
+    echo "ERROR: task_not_found: '$task_id'" >&2
+    exit 1
+  fi
+
+  task_status=$(jq -r --arg id "$task_id" '.phases[].tasks[] | select(.id == $id) | .status' "$plan_json")
+  if [[ "$task_status" == "complete" || "$task_status" == "skipped" ]]; then
+    unlock_plan "$plan_json"; trap - EXIT
+    echo "ERROR: cannot_modify_files: task '$task_id' is '$task_status' — files can only be removed from pending or in_progress tasks" >&2
+    exit 1
+  fi
+
+  local present
+  present=$(jq -r --arg id "$task_id" --arg kind "$kind" --arg p "$path" '
+    .phases[].tasks[] | select(.id == $id) | (.files[$kind] // []) | index($p) // ""
+  ' "$plan_json")
+  if [[ -z "$present" ]]; then
+    unlock_plan "$plan_json"; trap - EXIT
+    exit 0
+  fi
+
+  local tmp="${plan_json}.tmp.$$"
+  jq --arg id "$task_id" --arg kind "$kind" --arg p "$path" '
+    (.phases[].tasks[] | select(.id == $id) | .files[$kind]) |= ((. // []) | map(select(. != $p)))
+  ' "$plan_json" > "$tmp" || { rm -f "$tmp"; unlock_plan "$plan_json"; trap - EXIT; echo "ERROR: jq update failed" >&2; exit 1; }
+  mv "$tmp" "$plan_json" || { rm -f "$tmp"; unlock_plan "$plan_json"; trap - EXIT; echo "ERROR: failed to write plan.json" >&2; exit 1; }
+  do_render "$plan_json"
+  unlock_plan "$plan_json"
+  trap - EXIT
+}
+
 do_check_handoffs() {
   local plan_json="$1" phase_letter="$2"
   local plan_dir
@@ -1528,6 +1671,8 @@ UPDATE_STATUS=""
 CHECK_REVIEW_TYPE=""
 CHECK_REVIEW_SCOPE=""
 DEPENDS_ON_ID=""
+ADD_FILE_KIND=""
+ADD_FILE_PATH=""
 # shellcheck disable=SC2034
 CHECK_ENTRY_STAGE=""
 
@@ -1648,6 +1793,22 @@ while [[ $# -gt 0 ]]; do
         shift
       fi
       ;;
+    --add-file)
+      MODE="add-file"
+      shift
+      if [[ $# -gt 0 ]]; then
+        PLAN_JSON="$1"
+        shift
+      fi
+      ;;
+    --remove-file)
+      MODE="remove-file"
+      shift
+      if [[ $# -gt 0 ]]; then
+        PLAN_JSON="$1"
+        shift
+      fi
+      ;;
     --check-handoffs)
       MODE="check-handoffs"
       shift
@@ -1660,6 +1821,20 @@ while [[ $# -gt 0 ]]; do
       shift
       if [[ $# -gt 0 ]]; then
         DEPENDS_ON_ID="$1"
+        shift
+      fi
+      ;;
+    --kind)
+      shift
+      if [[ $# -gt 0 ]]; then
+        ADD_FILE_KIND="$1"
+        shift
+      fi
+      ;;
+    --path)
+      shift
+      if [[ $# -gt 0 ]]; then
+        ADD_FILE_PATH="$1"
         shift
       fi
       ;;
@@ -1742,6 +1917,20 @@ case "$MODE" in
       exit 2
     fi
     do_add_dep "$PLAN_JSON" "$UPDATE_ID" "$DEPENDS_ON_ID"
+    ;;
+  add-file)
+    if [[ "$UPDATE_TARGET" != "task" || -z "$UPDATE_ID" || -z "$ADD_FILE_KIND" || -z "$ADD_FILE_PATH" ]]; then
+      echo "ERROR: --add-file requires --task <ID> --kind <create|modify|test> --path <FILE>" >&2
+      exit 2
+    fi
+    do_add_file "$PLAN_JSON" "$UPDATE_ID" "$ADD_FILE_KIND" "$ADD_FILE_PATH"
+    ;;
+  remove-file)
+    if [[ "$UPDATE_TARGET" != "task" || -z "$UPDATE_ID" || -z "$ADD_FILE_KIND" || -z "$ADD_FILE_PATH" ]]; then
+      echo "ERROR: --remove-file requires --task <ID> --kind <create|modify|test> --path <FILE>" >&2
+      exit 2
+    fi
+    do_remove_file "$PLAN_JSON" "$UPDATE_ID" "$ADD_FILE_KIND" "$ADD_FILE_PATH"
     ;;
   check-handoffs)
     if [[ "$UPDATE_TARGET" != "phase" || -z "$UPDATE_ID" ]]; then

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,12 +1,21 @@
 {
   "hooks": {
-    "PreToolUse": [{
-      "matcher": "Bash",
-      "hooks": [{
-        "type": "command",
-        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse-deny-patterns.sh"
-      }]
-    }],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse-deny-patterns.sh"
+        }]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [{
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse-deny-plan-md.sh"
+        }]
+      }
+    ],
     "PermissionRequest": [
       {
         "matcher": "Read|Glob|Grep|Skill|WebFetch|WebSearch|ToolSearch|Bash",

--- a/hooks/pretooluse-deny-plan-md.sh
+++ b/hooks/pretooluse-deny-plan-md.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+input="$(cat)"
+tool_name="$(echo "$input" | jq -r '.tool_name // empty')"
+
+case "$tool_name" in
+  Edit|Write|MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+file_path="$(echo "$input" | jq -r '.tool_input.file_path // empty')"
+if [[ -z "$file_path" ]]; then
+  exit 0
+fi
+
+case "$file_path" in
+  */.claude/claude-caliper/*/plan.md)
+    reason="plan.md is a deterministic render of plan.json — direct edits are silently overwritten on the next validate-plan run. To change file lists, run: validate-plan --add-file <plan.json> --task <ID> --kind <create|modify|test> --path <FILE> (or --remove-file). To change task/phase status, run: validate-plan --update-status. To add a dependency, run: validate-plan --add-dep. After mutating plan.json, validate-plan re-renders plan.md automatically; if you need a manual re-render, run: validate-plan --render <plan.json>."
+    jq -nc --arg r "$reason" '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: $r
+      }
+    }'
+    exit 0
+    ;;
+esac
+
+exit 0

--- a/hooks/pretooluse-deny-plan-md.sh
+++ b/hooks/pretooluse-deny-plan-md.sh
@@ -14,8 +14,10 @@ if [[ -z "$file_path" ]]; then
   exit 0
 fi
 
-case "$file_path" in
-  */.claude/claude-caliper/*/plan.md)
+normalized_path="${file_path#./}"
+
+case "$normalized_path" in
+  .claude/claude-caliper/*/plan.md|*/.claude/claude-caliper/*/plan.md)
     reason="plan.md is a deterministic render of plan.json — direct edits are silently overwritten on the next validate-plan run. To change file lists, run: validate-plan --add-file <plan.json> --task <ID> --kind <create|modify|test> --path <FILE> (or --remove-file). To change task/phase status, run: validate-plan --update-status. To add a dependency, run: validate-plan --add-dep. After mutating plan.json, validate-plan re-renders plan.md automatically; if you need a manual re-render, run: validate-plan --render <plan.json>."
     jq -nc --arg r "$reason" '{
       hookSpecificOutput: {

--- a/tests/hooks/caliper-test_deny_plan_md.sh
+++ b/tests/hooks/caliper-test_deny_plan_md.sh
@@ -77,6 +77,14 @@ out=$(jq -n '{
 }' | "$HOOK" 2>/dev/null || true)
 assert_allow "Bash tool ignored" "$out"
 
+echo "Test 9: Edit on relative caliper plan.md is denied"
+out=$(run_hook "Edit" ".claude/claude-caliper/2026-04-28-topic/plan.md")
+assert_deny_contains "relative path denied" "$out" "--add-file"
+
+echo "Test 10: Edit on ./.claude caliper plan.md is denied"
+out=$(run_hook "Edit" "./.claude/claude-caliper/2026-04-28-topic/plan.md")
+assert_deny_contains "explicit ./ relative path denied" "$out" "--add-file"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 exit $FAIL

--- a/tests/hooks/caliper-test_deny_plan_md.sh
+++ b/tests/hooks/caliper-test_deny_plan_md.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$REPO_ROOT/hooks/pretooluse-deny-plan-md.sh"
+PASS=0
+FAIL=0
+
+assert_deny_contains() {
+  local desc="$1" output="$2" needle="$3"
+  if echo "$output" | grep -qF '"permissionDecision":"deny"' \
+     && echo "$output" | grep -qF -- "$needle"; then
+    echo "PASS: $desc"
+    ((PASS++)) || true
+  else
+    echo "FAIL: $desc (expected deny + '$needle')"
+    echo "  Got: $output"
+    ((FAIL++)) || true
+  fi
+}
+
+assert_allow() {
+  local desc="$1" output="$2"
+  if [[ -z "$output" ]]; then
+    echo "PASS: $desc"
+    ((PASS++)) || true
+  else
+    echo "FAIL: $desc (expected empty output, got: $output)"
+    ((FAIL++)) || true
+  fi
+}
+
+run_hook() {
+  local tool_name="$1" file_path="$2"
+  jq -n --arg t "$tool_name" --arg p "$file_path" '{
+    tool_name: $t,
+    tool_input: { file_path: $p },
+    session_id: "test-session"
+  }' | "$HOOK" 2>/dev/null || true
+}
+
+echo "Test 1: Edit on caliper plan.md is denied"
+out=$(run_hook "Edit" "/Users/foo/repo/.claude/claude-caliper/2026-04-28-topic/plan.md")
+assert_deny_contains "Edit denied with --add-file hint" "$out" "--add-file"
+assert_deny_contains "Edit denied with --render hint" "$out" "--render"
+
+echo "Test 2: Write on caliper plan.md is denied"
+out=$(run_hook "Write" "/Users/foo/repo/.claude/claude-caliper/2026-04-28-topic/plan.md")
+assert_deny_contains "Write denied" "$out" "permissionDecision"
+
+echo "Test 3: MultiEdit on caliper plan.md is denied"
+out=$(run_hook "MultiEdit" "/Users/foo/repo/.claude/claude-caliper/2026-04-28-topic/plan.md")
+assert_deny_contains "MultiEdit denied" "$out" "permissionDecision"
+
+echo "Test 4: Edit on phase-a/completion.md is allowed"
+out=$(run_hook "Edit" "/Users/foo/repo/.claude/claude-caliper/2026-04-28-topic/phase-a/completion.md")
+assert_allow "completion.md is editable" "$out"
+
+echo "Test 5: Edit on phase-a/a1.md is allowed"
+out=$(run_hook "Edit" "/Users/foo/repo/.claude/claude-caliper/2026-04-28-topic/phase-a/a1.md")
+assert_allow "task .md is editable" "$out"
+
+echo "Test 6: Edit on plan.md outside caliper tree is allowed"
+out=$(run_hook "Edit" "/Users/foo/some-other-repo/docs/plan.md")
+assert_allow "plan.md outside caliper tree is editable" "$out"
+
+echo "Test 7: Edit on unrelated path is allowed"
+out=$(run_hook "Edit" "/Users/foo/repo/src/index.ts")
+assert_allow "unrelated source file is editable" "$out"
+
+echo "Test 8: Bash tool with file_path-shaped command is ignored"
+out=$(jq -n '{
+  tool_name: "Bash",
+  tool_input: { command: "rm /tmp/.claude/claude-caliper/x/plan.md" },
+  session_id: "test-session"
+}' | "$HOOK" 2>/dev/null || true)
+assert_allow "Bash tool ignored" "$out"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+exit $FAIL

--- a/tests/validate-plan/caliper-test_add_remove_file.sh
+++ b/tests/validate-plan/caliper-test_add_remove_file.sh
@@ -115,17 +115,21 @@ assert_pass "remove absent path exits 0" \
 
 echo "Test 6: --remove-file create succeeds and re-renders plan.md"
 setup_valid_plan "$TMPDIR"
+rm -f "$TMPDIR/plan.md"
 assert_pass "remove existing create path" \
   "$VALIDATE" --remove-file "$TMPDIR/plan.json" --task A1 --kind create --path "src/core.ts"
 assert_json "src/core.ts removed from A1.files.create" "$TMPDIR/plan.json" \
   '(.phases[0].tasks[0].files.create | index("src/core.ts")) == null'
+assert_file_contains "plan.md re-rendered after create remove" "$TMPDIR/plan.md" "A1: Create core module"
 
 echo "Test 7: --remove-file test succeeds"
 setup_valid_plan "$TMPDIR"
+rm -f "$TMPDIR/plan.md"
 assert_pass "remove existing test path" \
   "$VALIDATE" --remove-file "$TMPDIR/plan.json" --task A1 --kind test --path "tests/core.test.ts"
 assert_json "tests/core.test.ts removed from A1.files.test" "$TMPDIR/plan.json" \
   '(.phases[0].tasks[0].files.test | index("tests/core.test.ts")) == null'
+assert_file_contains "plan.md re-rendered after test remove" "$TMPDIR/plan.md" "A1: Create core module"
 
 echo "Test 8: invalid kind is rejected"
 setup_valid_plan "$TMPDIR"

--- a/tests/validate-plan/caliper-test_add_remove_file.sh
+++ b/tests/validate-plan/caliper-test_add_remove_file.sh
@@ -57,17 +57,6 @@ assert_file_contains() {
   fi
 }
 
-assert_file_not_contains() {
-  local desc="$1" file="$2" needle="$3"
-  if ! grep -qF "$needle" "$file"; then
-    echo "PASS: $desc"
-    ((PASS++)) || true
-  else
-    echo "FAIL: $desc (unexpected '$needle' in $file)"
-    ((FAIL++)) || true
-  fi
-}
-
 setup_valid_plan() {
   local dir="$1"
   rm -rf "${dir:?}/"*

--- a/tests/validate-plan/caliper-test_add_remove_file.sh
+++ b/tests/validate-plan/caliper-test_add_remove_file.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+VALIDATE="$REPO_ROOT/bin/validate-plan"
+FIXTURES="$SCRIPT_DIR/fixtures"
+PASS=0
+FAIL=0
+
+assert_pass() {
+  local desc="$1"; shift
+  if "$@" > /dev/null 2>&1; then
+    echo "PASS: $desc"
+    ((PASS++)) || true
+  else
+    echo "FAIL: $desc"
+    ((FAIL++)) || true
+  fi
+}
+
+assert_fail() {
+  local desc="$1"; shift
+  local expected_error="$1"; shift
+  local output
+  if output=$("$@" 2>&1); then
+    echo "FAIL: $desc (expected failure, got success)"
+    ((FAIL++)) || true
+  elif echo "$output" | grep -q "$expected_error"; then
+    echo "PASS: $desc"
+    ((PASS++)) || true
+  else
+    echo "FAIL: $desc (expected '$expected_error' in output, got: $output)"
+    ((FAIL++)) || true
+  fi
+}
+
+assert_json() {
+  local desc="$1" plan="$2" filter="$3"
+  if jq -e "$filter" "$plan" > /dev/null 2>&1; then
+    echo "PASS: $desc"
+    ((PASS++)) || true
+  else
+    echo "FAIL: $desc (filter failed: $filter on $plan)"
+    ((FAIL++)) || true
+  fi
+}
+
+assert_file_contains() {
+  local desc="$1" file="$2" needle="$3"
+  if grep -qF "$needle" "$file"; then
+    echo "PASS: $desc"
+    ((PASS++)) || true
+  else
+    echo "FAIL: $desc (expected '$needle' in $file)"
+    ((FAIL++)) || true
+  fi
+}
+
+assert_file_not_contains() {
+  local desc="$1" file="$2" needle="$3"
+  if ! grep -qF "$needle" "$file"; then
+    echo "PASS: $desc"
+    ((PASS++)) || true
+  else
+    echo "FAIL: $desc (unexpected '$needle' in $file)"
+    ((FAIL++)) || true
+  fi
+}
+
+setup_valid_plan() {
+  local dir="$1"
+  rm -rf "${dir:?}/"*
+  cp -r "$FIXTURES/valid-plan/"* "$dir/"
+  cp "$FIXTURES/valid-plan/plan.json" "$dir/plan.json"
+}
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Test 1: --add-file create succeeds and re-renders plan.md"
+setup_valid_plan "$TMPDIR"
+assert_pass "add-file create on A1" \
+  "$VALIDATE" --add-file "$TMPDIR/plan.json" --task A1 --kind create --path "src/extra.ts"
+assert_json "src/extra.ts present in A1.files.create" "$TMPDIR/plan.json" \
+  '.phases[0].tasks[0].files.create | index("src/extra.ts")'
+assert_file_contains "plan.md re-rendered after create add" "$TMPDIR/plan.md" "A1: Create core module"
+
+echo "Test 2: --add-file modify succeeds"
+setup_valid_plan "$TMPDIR"
+assert_pass "add-file modify on A1" \
+  "$VALIDATE" --add-file "$TMPDIR/plan.json" --task A1 --kind modify --path "src/util.ts"
+assert_json "src/util.ts present in A1.files.modify" "$TMPDIR/plan.json" \
+  '.phases[0].tasks[0].files.modify | index("src/util.ts")'
+
+echo "Test 3: --add-file test succeeds"
+setup_valid_plan "$TMPDIR"
+assert_pass "add-file test on A1" \
+  "$VALIDATE" --add-file "$TMPDIR/plan.json" --task A1 --kind test --path "tests/extra.test.ts"
+assert_json "tests/extra.test.ts present in A1.files.test" "$TMPDIR/plan.json" \
+  '.phases[0].tasks[0].files.test | index("tests/extra.test.ts")'
+
+echo "Test 4: --add-file is idempotent (re-add same path is no-op)"
+setup_valid_plan "$TMPDIR"
+"$VALIDATE" --add-file "$TMPDIR/plan.json" --task A1 --kind modify --path "src/util.ts" > /dev/null 2>&1
+assert_pass "re-add same path exits 0" \
+  "$VALIDATE" --add-file "$TMPDIR/plan.json" --task A1 --kind modify --path "src/util.ts"
+assert_json "src/util.ts appears exactly once" "$TMPDIR/plan.json" \
+  '.phases[0].tasks[0].files.modify | map(select(. == "src/util.ts")) | length == 1'
+
+echo "Test 5: --remove-file is idempotent (absent path is no-op)"
+setup_valid_plan "$TMPDIR"
+assert_pass "remove absent path exits 0" \
+  "$VALIDATE" --remove-file "$TMPDIR/plan.json" --task A1 --kind modify --path "src/never-existed.ts"
+
+echo "Test 6: --remove-file create succeeds and re-renders plan.md"
+setup_valid_plan "$TMPDIR"
+assert_pass "remove existing create path" \
+  "$VALIDATE" --remove-file "$TMPDIR/plan.json" --task A1 --kind create --path "src/core.ts"
+assert_json "src/core.ts removed from A1.files.create" "$TMPDIR/plan.json" \
+  '(.phases[0].tasks[0].files.create | index("src/core.ts")) == null'
+
+echo "Test 7: --remove-file test succeeds"
+setup_valid_plan "$TMPDIR"
+assert_pass "remove existing test path" \
+  "$VALIDATE" --remove-file "$TMPDIR/plan.json" --task A1 --kind test --path "tests/core.test.ts"
+assert_json "tests/core.test.ts removed from A1.files.test" "$TMPDIR/plan.json" \
+  '(.phases[0].tasks[0].files.test | index("tests/core.test.ts")) == null'
+
+echo "Test 8: invalid kind is rejected"
+setup_valid_plan "$TMPDIR"
+assert_fail "add-file with --kind bogus" "invalid_kind" \
+  "$VALIDATE" --add-file "$TMPDIR/plan.json" --task A1 --kind bogus --path "src/x.ts"
+
+echo "Test 9: unknown task is rejected"
+setup_valid_plan "$TMPDIR"
+assert_fail "add-file on Z9" "task_not_found" \
+  "$VALIDATE" --add-file "$TMPDIR/plan.json" --task Z9 --kind create --path "src/x.ts"
+
+echo "Test 10: completed task rejects --add-file"
+setup_valid_plan "$TMPDIR"
+jq '.phases[0].tasks[0].status = "complete"' "$TMPDIR/plan.json" > "$TMPDIR/p.json" && mv "$TMPDIR/p.json" "$TMPDIR/plan.json"
+assert_fail "add-file on complete task" "cannot_modify_files" \
+  "$VALIDATE" --add-file "$TMPDIR/plan.json" --task A1 --kind create --path "src/x.ts"
+
+echo "Test 11: skipped task rejects --add-file"
+setup_valid_plan "$TMPDIR"
+jq '.phases[0].tasks[0].status = "skipped"' "$TMPDIR/plan.json" > "$TMPDIR/p.json" && mv "$TMPDIR/p.json" "$TMPDIR/plan.json"
+assert_fail "add-file on skipped task" "cannot_modify_files" \
+  "$VALIDATE" --add-file "$TMPDIR/plan.json" --task A1 --kind create --path "src/x.ts"
+
+echo "Test 12: completed task rejects --remove-file"
+setup_valid_plan "$TMPDIR"
+jq '.phases[0].tasks[0].status = "complete"' "$TMPDIR/plan.json" > "$TMPDIR/p.json" && mv "$TMPDIR/p.json" "$TMPDIR/plan.json"
+assert_fail "remove-file on complete task" "cannot_modify_files" \
+  "$VALIDATE" --remove-file "$TMPDIR/plan.json" --task A1 --kind create --path "src/core.ts"
+
+echo "Test 13: cross-kind conflict on same task is rejected"
+setup_valid_plan "$TMPDIR"
+assert_fail "add to modify when already in create on same task" "cross_kind_conflict" \
+  "$VALIDATE" --add-file "$TMPDIR/plan.json" --task A1 --kind modify --path "src/core.ts"
+
+echo "Test 14: per-phase overlap is rejected (same kind, different task)"
+setup_valid_plan "$TMPDIR"
+assert_fail "add to A2.create path already in A1.create" "fileset_overlap_add" \
+  "$VALIDATE" --add-file "$TMPDIR/plan.json" --task A2 --kind create --path "src/core.ts"
+
+echo "Test 15: per-phase overlap is rejected (different kinds, different tasks)"
+setup_valid_plan "$TMPDIR"
+assert_fail "add to A2.modify path already in A1.create" "fileset_overlap_add" \
+  "$VALIDATE" --add-file "$TMPDIR/plan.json" --task A2 --kind modify --path "src/core.ts"
+
+echo "Test 16: global create duplication is rejected (cross-phase)"
+setup_valid_plan "$TMPDIR"
+assert_fail "add to B1.create path already in A1.create" "duplicate_create_path_add" \
+  "$VALIDATE" --add-file "$TMPDIR/plan.json" --task B1 --kind create --path "src/core.ts"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+exit $FAIL


### PR DESCRIPTION
## Summary

Two additive changes:

- **PreToolUse deny hook for `plan.md`** — `hooks/pretooluse-deny-plan-md.sh` blocks Edit/Write/MultiEdit on any `*/.claude/claude-caliper/*/plan.md`. plan.md is deterministically rendered from plan.json by `validate-plan --render`; direct edits get clobbered on the next render. Deny message points to the source plan + the new CLI + `--render`.
- **`--add-file` and `--remove-file` modes in `bin/validate-plan`** — Mirrors `--add-dep`. Both lock plan.json, validate kind (`create|modify|test`), reject on complete/skipped tasks, and re-render plan.md on success. Add enforces cross-kind conflict on the same task, per-phase uniqueness across all kinds, and global uniqueness for `create`. Idempotent on re-add and absent-remove (exit 0, no render).

Marketplace version bumped to 1.42.0 across all three plugin entries.

## Test plan

- [x] `tests/hooks/caliper-test_deny_plan_md.sh` — 8 cases covering Edit/Write/MultiEdit deny, allow on completion.md / task .md / out-of-tree plan.md / unrelated paths / Bash
- [x] `tests/validate-plan/caliper-test_add_remove_file.sh` — 16 cases / 25 assertions covering success on each kind, idempotency, all 6 distinct error codes, and plan.md re-render after both add and remove
- [x] All existing hook tests (`caliper-test_safe_commands.sh`, `caliper-test_permission_request.sh`) and validate-plan suites pass unchanged

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI operations to add and remove files from tasks, including validation for task status, kind types, and conflict detection.
  * Implemented protection against editing auto-generated plan.md files, with guidance to use appropriate commands instead.

* **Chores**
  * Version bumped to 1.42.0 across all plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->