### PR TITLE
fix(worktree): scope subagent permissions correctly across worktrees

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.41.2",
+      "version": "1.41.3",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.41.2",
+      "version": "1.41.3",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.41.2",
+      "version": "1.41.3",
 
       "source": "./",
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "claude-caliper bundle",
 
 
-      "version": "1.41.1",
+      "version": "1.41.2",
 
       "source": "./",
       "author": {
@@ -38,7 +38,7 @@
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
 
 
-      "version": "1.41.1",
+      "version": "1.41.2",
 
       "source": "./",
       "author": {
@@ -64,7 +64,7 @@
       "description": "Standalone tools: codebase audit and skill evaluation",
 
 
-      "version": "1.41.1",
+      "version": "1.41.2",
 
       "source": "./",
       "author": {

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -32,9 +32,10 @@ Complete in order:
      MAIN_ROOT="$(git rev-parse --path-format=absolute --git-common-dir | sed 's|/\.git$||')"
      PLAN_DIR="$MAIN_ROOT/.claude/claude-caliper/YYYY-MM-DD-<topic>"
      WORKTREE="$MAIN_ROOT/.claude/worktrees/<feature>"
+     mkdir -p "$WORKTREE/.claude" && jq -n --arg d "$MAIN_ROOT" '{permissions:{additionalDirectories:[$d]}}' > "$WORKTREE/.claude/settings.local.json"
      ```
 
-     `$PLAN_DIR` lives in the main repo (gitignored) so plan artifacts survive worktree cleanup. Use `$PLAN_DIR` and `$WORKTREE` — not relative paths — in every dispatch prompt and `jq` write below; subagents inherit worktree CWD and relative `.claude/claude-caliper/...` won't resolve.
+     `$PLAN_DIR` lives in the main repo (gitignored) so plan artifacts survive worktree cleanup. Use `$PLAN_DIR` and `$WORKTREE` — not relative paths — in every dispatch prompt and `jq` write below; subagents inherit worktree CWD and relative `.claude/claude-caliper/...` won't resolve. The `settings.local.json` write registers `$MAIN_ROOT` as an additional directory so future sessions started inside the worktree (e.g. a fresh `claude` launched there) don't trigger per-command permission prompts when reading/writing `$PLAN_DIR`.
    - Multi-phase: rename to integration branch: `git branch -m integrate/<feature>` — phase worktrees created by orchestrate as siblings
    - Single-phase: branch name `<feature>` is correct as-is; orchestrate works here directly, PRs to main
    1. Bootstrap dependencies per **See:** ./dependency-bootstrap.md

--- a/skills/orchestrate/dispatch-subagents.md
+++ b/skills/orchestrate/dispatch-subagents.md
@@ -4,10 +4,14 @@ Parallel task execution via Agent tool dispatches with worktree isolation. No ex
 
 ## Dispatch Implementers
 
-For each task in the phase, check deps: `validate-plan --check-deps "$PLAN_JSON" --task {TASK_ID}`. Collect all tasks that pass. For each ready task, create a worktree and extract metadata (strip `status` — orchestrator state not needed by implementer):
+For each task in the phase, check deps: `validate-plan --check-deps "$PLAN_JSON" --task {TASK_ID}`. Collect all tasks that pass. For each ready task, create a worktree nested under the parent (feature or phase) worktree and extract metadata (strip `status` — orchestrator state not needed by implementer):
 
 ```bash
-git worktree add .claude/worktrees/{TASK_ID_LOWER} -b {TASK_ID_LOWER} HEAD
+PARENT_WORKTREE="$(git rev-parse --show-toplevel)"
+MAIN_ROOT="$(git rev-parse --path-format=absolute --git-common-dir | sed 's|/\.git$||')"
+[[ "$PARENT_WORKTREE" == "$MAIN_ROOT" ]] && { echo "ERROR: orchestrator CWD is the main repo; dispatching from here creates sibling task worktrees that trigger silent permission denials in background subagents. cd into the feature or phase worktree before dispatching." >&2; exit 1; }
+git -C "$PARENT_WORKTREE" worktree add .claude/worktrees/{TASK_ID_LOWER} -b {TASK_ID_LOWER} HEAD
+TASK_WORKTREE="$PARENT_WORKTREE/.claude/worktrees/{TASK_ID_LOWER}"
 TASK_METADATA=$(jq -c --arg id "{TASK_ID}" '[.phases[].tasks[] | select(.id == $id)][0] | del(.status)' "$PLAN_JSON")
 TASK_COMPLEXITY=$(echo "$TASK_METADATA" | jq -r '.complexity')
 REVIEWER_NEEDED=$(echo "$TASK_METADATA" | jq -r '.reviewer_needed')
@@ -90,3 +94,4 @@ When `REVIEWER_NEEDED` was `"false"`, skip step 1 — the skip verdict was alrea
 - No mailbox messaging — lead dispatches fix agents into the existing worktree
 - Worktrees are created by the orchestrator via `git worktree add` from the feature branch
 - Fix agents are dispatched into existing worktrees — the lead coordinates, implementers touch code
+- Task worktrees must nest **inside** the parent (feature or phase) worktree — anchor `git worktree add` with `git -C "$PARENT_WORKTREE"` so CWD drift never produces siblings under the main repo. Background subagents writing into a sibling worktree get silent permission denials because Claude Code scopes write permission to the parent session's project root, and they cannot answer the cross-directory prompt.


### PR DESCRIPTION
## Summary

Two related fixes that prevent silent permission denials when subagents work inside Claude-Caliper worktrees:

- **`feat(design): write settings.local.json with additionalDirectories on worktree setup`** — sessions started inside a worktree don't have the main repo path in their auto-approve scope, so reading/writing plan files in `$MAIN_ROOT/.claude/claude-caliper/` triggers per-command permission prompts. Writing `additionalDirectories` to the worktree's `settings.local.json` registers `$MAIN_ROOT` for future sessions.

- **`fix(orchestrate): anchor task worktree creation to parent worktree`** — when the orchestrator's CWD drifts to the main repo, `git worktree add .claude/worktrees/<task>` resolves to a sibling of the parent worktree. Background subagents writing into siblings hit silent permission denials (Claude Code scopes write permission to the parent session's project root, and background subagents cannot answer the cross-directory prompt). The fix captures the parent worktree via `git rev-parse --show-toplevel`, aborts hard if it equals `MAIN_ROOT`, and runs `git worktree add` through `git -C "$PARENT_WORKTREE"` so nesting is CWD-independent.

Bumps marketplace version 1.41.2 -> 1.41.3.

## Test plan

- [ ] Run an orchestrate dispatch from the feature worktree and confirm task worktrees land at `<feature>/.claude/worktrees/<task>` (nested), not `<main>/.claude/worktrees/<task>` (sibling)
- [ ] Force CWD drift to the main repo before dispatch and confirm the guard aborts with the new error message
- [ ] Launch a fresh `claude` session inside an existing worktree and confirm reads/writes to `$MAIN_ROOT/.claude/claude-caliper/` no longer prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)