### PR TITLE
fix(hooks): basename-strip absolute paths in $(...) subshells

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.42.0",
+      "version": "1.42.1",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -33,7 +33,7 @@
     {
       "name": "claude-caliper-workflow",
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
-      "version": "1.42.0",
+      "version": "1.42.1",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -56,7 +56,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit and skill evaluation",
-      "version": "1.42.0",
+      "version": "1.42.1",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/hooks/lib-command-parser.sh
+++ b/hooks/lib-command-parser.sh
@@ -130,10 +130,12 @@ extract_command_words_from_segment() {
     local inner="${BASH_REMATCH[1]}"
     inner="${inner#"${inner%%[![:space:]]*}"}"
     outer_cmd="${inner%% *}"
+    outer_cmd="${outer_cmd##*/}"
   elif [[ "$seg" =~ $var_subshell_re ]]; then
     local inner="${BASH_REMATCH[1]}"
     inner="${inner#"${inner%%[![:space:]]*}"}"
     outer_cmd="${inner%% *}"
+    outer_cmd="${outer_cmd##*/}"
   elif [[ "$seg" =~ $var_ref_re ]]; then
     : # VAR=$other/path — variable reference assignment, not a command
   elif [[ "$seg" =~ $array_assign_re ]]; then

--- a/tests/hooks/caliper-test_safe_commands.sh
+++ b/tests/hooks/caliper-test_safe_commands.sh
@@ -396,6 +396,20 @@ cp "$REPO_ROOT/hooks/safe-commands.txt" "$SAFE57"
 OUT57=$(run_allow 'PLAN_DIR=/repo/.claude/caliper/plan; PLAN_JSON=$PLAN_DIR/plan.json; TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ"); jq --arg ts "$TS" ". += [{\"verdict\":\"pass\",\"timestamp\":\$ts}]" "$PLAN_DIR/reviews.json" > "$PLAN_DIR/reviews.json.tmp" && mv "$PLAN_DIR/reviews.json.tmp" "$PLAN_DIR/reviews.json"; TODAY=$(date +"%Y-%m-%d"); validate-plan --update-status "$PLAN_JSON" --phase A --status "Complete ($TODAY)"' "$SAFE57")
 assert_output_contains "phase-complete pattern with date allowed" "$OUT57" '"behavior":"allow"'
 
+echo "Test 57b: VAR=\$(/abs/path/cmd args) — absolute path inside subshell assignment"
+SAFE57B="$TMPDIR_TEST/safe57b.txt"
+printf 'caliper-settings\n' > "$SAFE57B"
+# shellcheck disable=SC2016
+OUT57B=$(run_allow 'PR_REVIEWER_MODEL=$(/Users/me/repo/bin/caliper-settings get pr_reviewer_model)' "$SAFE57B")
+assert_output_contains "VAR=\$(/abs/path/cmd) basename-stripped and allowed" "$OUT57B" '"behavior":"allow"'
+
+echo "Test 57c: \$(/abs/path/cmd args) — absolute path inside pure subshell"
+SAFE57C="$TMPDIR_TEST/safe57c.txt"
+printf 'caliper-settings\n' > "$SAFE57C"
+# shellcheck disable=SC2016
+OUT57C=$(run_allow '$(/Users/me/repo/bin/caliper-settings get pr_reviewer_model)' "$SAFE57C")
+assert_output_contains "\$(/abs/path/cmd) basename-stripped and allowed" "$OUT57C" '"behavior":"allow"'
+
 echo "Test 58: VAR=(...) bash array literal allowed when body cmds are safe"
 SAFE58="$TMPDIR_TEST/safe58.txt"
 cp "$REPO_ROOT/hooks/safe-commands.txt" "$SAFE58"


### PR DESCRIPTION
## Summary
- `extract_command_words_from_segment` skipped basename-strip for `$(...)` and `VAR=$(...)` branches, while the bare-command, bash-script, and trailing-subshell branches all applied it
- Result: `VAR=$(/abs/path/cmd args)` registered both `cmd` (matched safe list) and `/abs/path/cmd` (didn't), flipping `all_safe` to 0 — triggered a permission prompt for invocations like `PR_REVIEWER_MODEL=$(/path/to/bin/caliper-settings get ...)`
- Adds `outer_cmd="\${outer_cmd##*/}"` to both branches and regression tests 57b/57c

## Test plan
- [x] Reproduced the bug: command logged `/Users/.../bin/caliper-settings` as non-matching
- [x] After fix: same command emits the expected `behavior":"allow"` JSON
- [x] `tests/hooks/caliper-test_safe_commands.sh` — 95 passed, 0 failed (was 93)
- [x] `tests/hooks/caliper-test_permission_request.sh` — 19 passed, 0 failed

Co-Authored-By: Claude <noreply@anthropic.com>