### PR TITLE
fix(orchestrate): guard against implementer committing to wrong worktree

### DIFF
--- a/agents/task-implementer.md
+++ b/agents/task-implementer.md
@@ -10,7 +10,13 @@ background: true
 
 ## Worktree Isolation
 
-You are working in an isolated git worktree. All code changes, file creation, and commits happen in the worktree specified by your invocation prompt. In agent-teams mode, this is your auto-provisioned CWD. In subagents mode, the orchestrator provides the worktree as an absolute path — use it for all file operations. The plan directory path is a cross-worktree path for reading plan artifacts only — never cd there or write code there.
+You are working in an isolated git worktree. All code changes, file creation, and commits happen in the worktree specified by your invocation prompt.
+
+**In subagents mode:** Your inherited CWD is the orchestrator's worktree — not yours. Your first bash command must be `cd <WORKTREE_PATH>` (from the Paths section). Verify `git branch --show-current` shows your task branch before touching any files. If the branch is wrong, stop and report — never commit from the wrong worktree.
+
+**In agent-teams mode:** The auto-provisioned CWD is already your worktree. Verify `git branch --show-current` at startup.
+
+The plan directory path is a cross-worktree path for reading plan artifacts only — never cd there or write code there.
 
 ## Your Job
 

--- a/skills/orchestrate/dispatch-subagents.md
+++ b/skills/orchestrate/dispatch-subagents.md
@@ -10,6 +10,7 @@ For each task in the phase, check deps: `validate-plan --check-deps "$PLAN_JSON"
 PARENT_WORKTREE="$(git rev-parse --show-toplevel)"
 MAIN_ROOT="$(git rev-parse --path-format=absolute --git-common-dir | sed 's|/\.git$||')"
 [[ "$PARENT_WORKTREE" == "$MAIN_ROOT" ]] && { echo "ERROR: orchestrator CWD is the main repo; dispatching from here creates sibling task worktrees that trigger silent permission denials in background subagents. cd into the feature or phase worktree before dispatching." >&2; exit 1; }
+PRE_TASK_SHA=$(git -C "$PARENT_WORKTREE" rev-parse HEAD)
 git -C "$PARENT_WORKTREE" worktree add .claude/worktrees/{TASK_ID_LOWER} -b {TASK_ID_LOWER} HEAD
 TASK_WORKTREE="$PARENT_WORKTREE/.claude/worktrees/{TASK_ID_LOWER}"
 TASK_METADATA=$(jq -c --arg id "{TASK_ID}" '[.phases[].tasks[] | select(.id == $id)][0] | del(.status)' "$PLAN_JSON")
@@ -42,13 +43,19 @@ The agent runs in background automatically (defined in agent frontmatter). Track
 When a background agent completes (push notification — do not poll):
 
 1. Read the agent's return message for completion notes and task summary
-1a. Verify the commit landed on the task branch — not the parent worktree's branch:
+2. Verify the commit landed on the task branch — not the parent worktree's branch. The real check is whether the parent HEAD is still at `PRE_TASK_SHA`:
     ```bash
-    git -C "$TASK_WORKTREE" log --oneline -3 && git -C "$TASK_WORKTREE" branch --show-current
+    git -C "$TASK_WORKTREE" log --oneline -3 --decorate
+    git -C "$PARENT_WORKTREE" rev-parse HEAD
     ```
-    Output must show `{TASK_ID_LOWER}`. If commits are on the wrong branch (e.g., the parent branch), correct it before dispatching the reviewer: advance `{TASK_ID_LOWER}` to current HEAD (`git -C "$TASK_WORKTREE" reset --hard <wrong-HEAD-sha>`), then reset the parent branch back to its pre-task SHA.
-2. Check `REVIEWER_NEEDED`:
-   - If `"false"`: record a skip in reviews.json (`"verdict":"skip","reason":"reviewer_needed: false"`) and proceed directly to step 2 of "After Review Passes" (skip step 1 — verdict already recorded). Skip steps 3-4.
+    Parent HEAD must still equal `$PRE_TASK_SHA`. If it has advanced, the implementer committed to the parent branch instead. Correct before dispatching the reviewer:
+    ```bash
+    WRONG_HEAD=$(git -C "$PARENT_WORKTREE" rev-parse HEAD)
+    git -C "$TASK_WORKTREE" reset --hard "$WRONG_HEAD"
+    git -C "$PARENT_WORKTREE" reset --hard "$PRE_TASK_SHA"
+    ```
+3. Check `REVIEWER_NEEDED`:
+   - If `"false"`: record a skip in reviews.json (`"verdict":"skip","reason":"reviewer_needed: false"`) and proceed directly to step 2 of "After Review Passes" (skip step 1 — verdict already recorded). Skip steps 4-5.
    - If `"true"`: dispatch a reviewer (synchronous — override background with `run_in_background: false` so the lead waits for results):
 
 ```text
@@ -62,8 +69,8 @@ Agent(
 )
 ```
 
-3. Extract the last `json review-summary` block from reviewer output
-4. Triage issues: "fix" or "dismiss" (with reasoning)
+4. Extract the last `json review-summary` block from reviewer output
+5. Triage issues: "fix" or "dismiss" (with reasoning)
 
 ## Review Fix Cycle
 

--- a/skills/orchestrate/dispatch-subagents.md
+++ b/skills/orchestrate/dispatch-subagents.md
@@ -42,6 +42,11 @@ The agent runs in background automatically (defined in agent frontmatter). Track
 When a background agent completes (push notification — do not poll):
 
 1. Read the agent's return message for completion notes and task summary
+1a. Verify the commit landed on the task branch — not the parent worktree's branch:
+    ```bash
+    git -C "$TASK_WORKTREE" log --oneline -3 && git -C "$TASK_WORKTREE" branch --show-current
+    ```
+    Output must show `{TASK_ID_LOWER}`. If commits are on the wrong branch (e.g., the parent branch), correct it before dispatching the reviewer: advance `{TASK_ID_LOWER}` to current HEAD (`git -C "$TASK_WORKTREE" reset --hard <wrong-HEAD-sha>`), then reset the parent branch back to its pre-task SHA.
 2. Check `REVIEWER_NEEDED`:
    - If `"false"`: record a skip in reviews.json (`"verdict":"skip","reason":"reviewer_needed: false"`) and proceed directly to step 2 of "After Review Passes" (skip step 1 — verdict already recorded). Skip steps 3-4.
    - If `"true"`: dispatch a reviewer (synchronous — override background with `run_in_background: false` so the lead waits for results):

--- a/skills/orchestrate/implementer-prompt.md
+++ b/skills/orchestrate/implementer-prompt.md
@@ -41,7 +41,7 @@ Agent(
 
     ## Before You Begin
 
-    1. Navigate to your worktree and verify you are on the correct branch:
+    1. *(Subagents mode only — omit this step in agent-teams mode)* Navigate to your worktree and verify you are on the correct branch:
        ```bash
        cd {WORKTREE_PATH} && git branch --show-current
        ```

--- a/skills/orchestrate/implementer-prompt.md
+++ b/skills/orchestrate/implementer-prompt.md
@@ -41,7 +41,15 @@ Agent(
 
     ## Before You Begin
 
-    Mark your task in-progress:
-    validate-plan --update-status {PLAN_DIR}/plan.json --task {TASK_ID} --status in_progress"
+    1. Navigate to your worktree and verify you are on the correct branch:
+       ```bash
+       cd {WORKTREE_PATH} && git branch --show-current
+       ```
+       Output must be `{TASK_ID_LOWER}`. If it shows any other branch, stop and report the mismatch — do not commit anything.
+
+    2. Mark your task in-progress:
+       ```bash
+       validate-plan --update-status {PLAN_DIR}/plan.json --task {TASK_ID} --status in_progress
+       ```"
 )
 ```


### PR DESCRIPTION
## Summary

- Task-implementer subagents inherit the orchestrator's CWD, so without an explicit `cd` into the task worktree they silently commit to the parent/integration branch instead of their isolated task branch (observed in session fd47c82d)
- `implementer-prompt.md`: `cd {WORKTREE_PATH} && git branch --show-current` is now step 1 of "Before You Begin", with a hard stop if the branch doesn't match — happens before marking in-progress
- `task-implementer.md`: "Worktree Isolation" section now explicitly calls out that the inherited CWD is the orchestrator's and the first bash command must be `cd <WORKTREE_PATH>`
- `dispatch-subagents.md`: new step 1a after agent completion verifies the commit landed on the task branch before reviewer dispatch, with a correction recipe (branch pointer surgery) if it didn't

## Test plan

- [ ] Dispatch a subagent implementer and confirm its first action is `cd <worktree> && git branch --show-current`
- [ ] Confirm implementer halts and reports if the branch check fails
- [ ] Confirm orchestrator verifies branch after agent completes before dispatching reviewer

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced worktree isolation guidance with explicit branch verification requirements for task execution modes, reducing risk of incorrect branch commits.
  * Added pre-dispatch validation checks to confirm task branches are correct before reviewer notification, improving system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->