### PR TITLE
fix(hooks): add [[ to safe-commands for double-bracket conditionals

### DIFF
--- a/hooks/safe-commands.txt
+++ b/hooks/safe-commands.txt
@@ -48,6 +48,7 @@ xargs
 ln
 dirname
 basename
+[[
 [
 command
 case

--- a/tests/hooks/caliper-test_safe_commands.sh
+++ b/tests/hooks/caliper-test_safe_commands.sh
@@ -536,6 +536,12 @@ echo "Test 40d: Safe command produces no output from deny hook"
 OUT40D=$(run_deny "git status")
 assert_output_empty "safe command not denied" "$OUT40D"
 
+echo "Test 41b: [[ double-bracket conditional allowed (setup command pattern)"
+SAF41B="$TMPDIR_TEST/safe41b.txt"
+cp "$REPO_ROOT/hooks/safe-commands.txt" "$SAF41B"
+OUT41B=$(run_allow 'MAIN_REPO="$(git worktree list --porcelain | head -1 | sed '"'"'s/^worktree //'"'"')" && BRANCH_NAME=$(git branch --show-current) && [[ "$BRANCH_NAME" == integrate/* ]] && echo "IS_INTEGRATION=true" || echo "IS_INTEGRATION=false"' "$SAF41B")
+assert_output_contains "[[ conditional in setup command allowed" "$OUT41B" '"behavior":"allow"'
+
 echo ""
 echo "$PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary
- `[[` (bash double-bracket test) was missing from `safe-commands.txt`, causing commands like `[[ "$BRANCH_NAME" == integrate/* ]]` to fall through to Claude Code's tree-sitter parser, which emits "Unhandled node type: string" and shows a generic permission prompt
- `[` (single bracket) was already listed; `[[` is equivalent and equally safe
- Added a regression test (test 41b) covering the full setup-variable pattern from the pr-merge skill

## Test plan
- [ ] `./tests/hooks/caliper-test_safe_commands.sh` — 96 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)