### PR TITLE
fix(pr-review): use three-dot diff to avoid phantom-revert findings

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.42.5",
+      "version": "1.42.6",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -33,7 +33,7 @@
     {
       "name": "claude-caliper-workflow",
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
-      "version": "1.42.5",
+      "version": "1.42.6",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -56,7 +56,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit and skill evaluation",
-      "version": "1.42.5",
+      "version": "1.42.6",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -58,7 +58,7 @@ Skip if `--skip-review` passed or `caliper-settings get skip_review` returns `tr
 Read PR reviewer model: `caliper-settings get pr_reviewer_model` — substitute into `reviewer-prompt.md`'s `model:` field.
 
 Read `reviewer-prompt.md` and dispatch with `run_in_background: true`:
-- `{DIFF_RANGE}` = `origin/$BASE_BRANCH..HEAD`
+- `{DIFF_RANGE}` = `origin/$BASE_BRANCH...HEAD` (three-dot — merge-base diff, matches GitHub's PR view; two-dot includes phantom-reverts of base commits when the branch is behind)
 - `{REPO_PATH}` = repository root
 - `{PR_NUMBER}` = PR number
 


### PR DESCRIPTION
## Summary

- Switch `pr-review` reviewer's `{DIFF_RANGE}` from two-dot (`origin/$BASE..HEAD`) to three-dot (`origin/$BASE...HEAD`) so the diff scopes to the PR's actual contributions (merge-base diff), matching GitHub's PR view.
- Bump marketplace version to 1.42.6.

## Why

When the PR branch is behind base (any commits merged after branch-off), two-dot includes those base commits as **phantom-reverts** — the reviewer sees code on base but not on the branch and flags it as a regression. Findings disappear after rebase, but rebase isn't always possible mid-session.

I audited the rest of `skills/`. Other reviewer dispatches (`implementation-review`, `orchestrate` task/phase/final reviewers) use captured commit SHAs (`BASE_SHA..HEAD_SHA`), which are immutable linear ancestors of HEAD by construction — two-dot is correct there. `pr-review` was the only callsite with a moving ref.

Closes #236

## Test plan

- [ ] Run pr-review on a stale branch (1+ commits behind base) and confirm phantom-revert findings no longer appear
- [ ] Run pr-review on an up-to-date branch and confirm findings unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin versions for claude-caliper, claude-caliper-workflow, and claude-caliper-tooling to 1.42.6.

* **Bug Fixes**
  * Refined pr-review skill diff range configuration to improve accuracy of pull request diff calculations during code reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->