### PR TITLE
docs(design): relax design doc length cap to 3000 words

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.43.0",
+      "version": "1.43.1",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -33,7 +33,7 @@
     {
       "name": "claude-caliper-workflow",
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
-      "version": "1.43.0",
+      "version": "1.43.1",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -56,7 +56,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit and skill evaluation",
-      "version": "1.43.0",
+      "version": "1.43.1",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/skills/design/design-spec.md
+++ b/skills/design/design-spec.md
@@ -148,7 +148,7 @@ File paths and structural code snippets can appear in both — the design descri
 
 ## Writing Guidance
 
-**Target length:** ~1,500 words. Design docs longer than 2,000 words are usually carrying plan-level detail that should be removed, or architecture prose that should be moved to a table.
+**Length:** Design docs longer than 3,000 words are usually carrying plan-level detail that should be removed, or architecture prose that should be moved to a table.
 
 **Use explicit structure over prose.** The plan-drafter reads literally. Headers, bullet points, and tables are parsed more reliably than paragraphs. Avoid "as mentioned above" — the plan-drafter may not have that context anchored.
 


### PR DESCRIPTION
## Summary
- Drop the ~1,500 word target from design-spec.md and raise the soft cap from 2,000 to 3,000 words
- Bump marketplace.json from 1.43.0 to 1.43.1

## Test plan
- [x] Manual review of design-spec.md change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released plugin version 1.43.1.

* **Documentation**
  * Updated design documentation guidelines for improved guidance on document scope and organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikhilsitaram/claude-caliper/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->