### PR TITLE
feat(design-review): step down opus to sonnet at iter >= 3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.43.2",
+      "version": "1.43.3",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -33,7 +33,7 @@
     {
       "name": "claude-caliper-workflow",
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
-      "version": "1.43.2",
+      "version": "1.43.3",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -56,7 +56,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit and skill evaluation",
-      "version": "1.43.2",
+      "version": "1.43.3",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/defaults.json
+++ b/defaults.json
@@ -69,7 +69,7 @@
     "type": "enum",
     "values": ["opus", "sonnet", "haiku"],
     "default": "opus",
-    "description": "Model for design review",
+    "description": "Model for design review (iter 1–2). When set to opus, re-dispatches at iter ≥ 3 step down to sonnet automatically — verification passes don't justify opus cost.",
     "used_by": ["design", "design-review"]
   },
   "plan_reviewer_model": {

--- a/skills/design-review/SKILL.md
+++ b/skills/design-review/SKILL.md
@@ -51,6 +51,7 @@ Reviewer produces:
 **Re-review gate (design-review):** The design skill controls the review loop with these rules:
 - **Batch-fix discipline:** All issues from a review are triaged (fix or dismiss with reasoning) in one pass before re-dispatching
 - **Delta context (iter ≥2):** Follow-up reviewers receive the prior iteration's issues with resolution status, enabling verify-then-scan instead of full re-discovery
+- **Model step-down (iter ≥3):** When `design_reviewer_model` is `opus`, re-dispatches at iter ≥ 3 use `sonnet` instead — verification-heavy passes don't justify the opus cost
 - **Severity-gated termination (after iter 3):** Remaining `low` and `medium` issues are auto-dismissed; only `high` and `critical` issues block planning past iteration 3
 
 Note: Plan-review uses a separate gate — `caliper-settings get re_review_threshold`. That gate is unchanged.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -129,12 +129,18 @@ After each reviewer dispatch, extract the `json review-summary` block from the r
    - `resolution`: `"fixed"` or `"dismissed"`
    - `dismissal_reason`: present only when dismissed
 
+   **Model step-down for iter ≥ 3:** Re-reviews past iter 2 are verification-heavy (did the prior issues get fixed?) rather than discovery-heavy, and don't justify the opus cost. When `ITER ≥ 3` and `DESIGN_REVIEWER_MODEL` is `opus`, use `sonnet` for the re-dispatch instead. Resolve with:
+
+   ```bash
+   if [ "$ITER" -ge 3 ] && [ "$DESIGN_REVIEWER_MODEL" = "opus" ]; then ITER_MODEL=sonnet; else ITER_MODEL="$DESIGN_REVIEWER_MODEL"; fi
+   ```
+
    Dispatch with `## Prior Issues` appended after the "Codebase root" line:
 
    ```text
    Agent(
      subagent_type: "claude-caliper:design-reviewer",
-     model: "$DESIGN_REVIEWER_MODEL",
+     model: "$ITER_MODEL",
      prompt: "Review the design doc at $PLAN_DIR/design-<topic>.md
 
        Codebase root: $WORKTREE


### PR DESCRIPTION
## Summary
- At iter >= 3, design-review re-dispatches step down from `opus` to `sonnet`. Iters 1-2 still use `design_reviewer_model`; if it's already sonnet/haiku, behavior is unchanged.
- Rationale: re-reviews past iter 2 are verification-heavy (did the prior issues get fixed?) rather than discovery-heavy and don't justify opus cost.
- Bumps marketplace.json 1.43.2 → 1.43.3.

## Test plan
- [x] `caliper-test_*` suite passes locally
- [ ] Trigger a design-review loop that goes past iter 2 and confirm the re-dispatch uses sonnet

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated three plugin versions to 1.43.3.

* **New Features**
  * Design review now automatically adjusts its model selection for iterations beyond step 3, improving efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikhilsitaram/claude-caliper/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->