### PR TITLE
fix(orchestrate): symlink worktree agent-memory to main repo (#244)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.43.3",
+      "version": "1.44.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -33,7 +33,7 @@
     {
       "name": "claude-caliper-workflow",
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
-      "version": "1.43.3",
+      "version": "1.44.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -56,7 +56,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit and skill evaluation",
-      "version": "1.43.3",
+      "version": "1.44.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/bin/link-agent-memory
+++ b/bin/link-agent-memory
@@ -38,7 +38,7 @@ LINK="$WORKTREE/.claude/agent-memory"
 mkdir -p "$(dirname "$LINK")"
 
 if [[ -L "$LINK" ]]; then
-  current="$(readlink -- "$LINK")"
+  current="$(readlink "$LINK")"
   if [[ "$current" == "$TARGET" ]]; then
     exit 0
   fi

--- a/bin/link-agent-memory
+++ b/bin/link-agent-memory
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# link-agent-memory <worktree-path>
+#
+# Symlink <worktree>/.claude/agent-memory -> $MAIN_ROOT/.claude/agent-memory so
+# subagents dispatched from inside a worktree (whose memory: project frontmatter
+# tells Claude Code to write .claude/agent-memory/<name>/ relative to CWD) write
+# through to the main repo. Without this, worktree cleanup silently deletes the
+# memory directory along with everything else under the worktree.
+#
+# Idempotent: re-running on a worktree that already has the correct symlink is
+# a no-op. Fails loudly if a real directory or a mis-targeted symlink already
+# occupies the link path — preserves any in-flight memory until the user moves
+# it manually.
+
+usage() {
+  echo "Usage: link-agent-memory <worktree-path>" >&2
+  exit 1
+}
+
+[[ $# -eq 1 ]] || usage
+
+WORKTREE="$1"
+[[ -d "$WORKTREE" ]] || { echo "ERROR: worktree path does not exist: $WORKTREE" >&2; exit 1; }
+
+MAIN_ROOT="$(git -C "$WORKTREE" rev-parse --path-format=absolute --git-common-dir | sed 's|/\.git$||')"
+
+# Running inside the main repo is a no-op — memory already lives there.
+if [[ "$(cd "$WORKTREE" && pwd -P)" == "$(cd "$MAIN_ROOT" && pwd -P)" ]]; then
+  exit 0
+fi
+
+TARGET="$MAIN_ROOT/.claude/agent-memory"
+mkdir -p "$TARGET"
+
+LINK="$WORKTREE/.claude/agent-memory"
+mkdir -p "$(dirname "$LINK")"
+
+if [[ -L "$LINK" ]]; then
+  current="$(readlink -- "$LINK")"
+  if [[ "$current" == "$TARGET" ]]; then
+    exit 0
+  fi
+  echo "ERROR: $LINK is a symlink pointing to $current; refusing to overwrite" >&2
+  exit 1
+fi
+
+if [[ -e "$LINK" ]]; then
+  echo "ERROR: $LINK already exists as a non-symlink; refusing to overwrite. Move any in-flight memory to $TARGET and remove $LINK before retrying." >&2
+  exit 1
+fi
+
+ln -s "$TARGET" "$LINK"

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -33,9 +33,10 @@ Complete in order:
      PLAN_DIR="$MAIN_ROOT/.claude/claude-caliper/YYYY-MM-DD-<topic>"
      WORKTREE="$MAIN_ROOT/.claude/worktrees/<feature>"
      mkdir -p "$WORKTREE/.claude" && jq -n --arg d "$MAIN_ROOT" '{permissions:{additionalDirectories:[$d]}}' > "$WORKTREE/.claude/settings.local.json"
+     link-agent-memory "$WORKTREE"
      ```
 
-     `$PLAN_DIR` lives in the main repo (gitignored) so plan artifacts survive worktree cleanup. Use `$PLAN_DIR` and `$WORKTREE` — not relative paths — in every dispatch prompt and `jq` write below; subagents inherit worktree CWD and relative `.claude/claude-caliper/...` won't resolve. The `settings.local.json` write registers `$MAIN_ROOT` as an additional directory so future sessions started inside the worktree (e.g. a fresh `claude` launched there) don't trigger per-command permission prompts when reading/writing `$PLAN_DIR`.
+     `$PLAN_DIR` lives in the main repo (gitignored) so plan artifacts survive worktree cleanup. Use `$PLAN_DIR` and `$WORKTREE` — not relative paths — in every dispatch prompt and `jq` write below; subagents inherit worktree CWD and relative `.claude/claude-caliper/...` won't resolve. The `settings.local.json` write registers `$MAIN_ROOT` as an additional directory so future sessions started inside the worktree (e.g. a fresh `claude` launched there) don't trigger per-command permission prompts when reading/writing `$PLAN_DIR`. `link-agent-memory` symlinks `$WORKTREE/.claude/agent-memory` to `$MAIN_ROOT/.claude/agent-memory` so subagents with `memory: project` (design-reviewer, plan-drafter, plan-reviewer, task-implementer, implementation-reviewer) persist memory through worktree cleanup.
    - Multi-phase: rename to integration branch: `git branch -m integrate/<feature>` — phase worktrees created by orchestrate as siblings
    - Single-phase: branch name `<feature>` is correct as-is; orchestrate works here directly, PRs to main
    1. Bootstrap dependencies per **See:** ./dependency-bootstrap.md

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -61,7 +61,7 @@ Process phases in order (A, B, C...). For each phase:
 
 1. Determine phase resumption state (multi-phase only — single-phase: use feature worktree, no resumption check needed). Phase status is the primary signal because squash-merge in step 7 typically deletes the phase branch ref, making `git merge-base --is-ancestor` unreliable.
    - If phase status starts with "Complete": run `gh pr list --base integrate/<feature> --head phase-<letter> --state merged --json number --jq 'length'`. If non-zero, the phase is fully merged — skip to next phase. If zero (status Complete but PR not yet merged), skip directly to Phase Wrap-Up step 7, reusing any open PR or creating one if absent.
-   - Otherwise (status "Not Started" or "In Progress"): create phase worktree from integration branch and continue with the remaining numbered steps below (`validate-plan --check-base`, etc.).
+   - Otherwise (status "Not Started" or "In Progress"): create phase worktree from integration branch (`git worktree add "$MAIN_ROOT/.claude/worktrees/<feature>-phase-<letter>" -b phase-<letter>`), then `link-agent-memory "$MAIN_ROOT/.claude/worktrees/<feature>-phase-<letter>"` so the implementation-reviewer dispatched at Phase Wrap-Up persists memory through cleanup. Continue with the remaining numbered steps below (`validate-plan --check-base`, etc.).
 2. Re-validate base branch: `validate-plan --check-base "$PLAN_JSON"` (multi-phase only — ensures dispatch happens from integration worktree, not main)
 3. `PHASE_BASE_SHA=$(git rev-parse HEAD)` in worktree
 4. **Bootstrap dependencies** in the worktree. **See:** skills/design/dependency-bootstrap.md

--- a/skills/orchestrate/dispatch-agent-teams.md
+++ b/skills/orchestrate/dispatch-agent-teams.md
@@ -36,6 +36,8 @@ Spawn **all ready implementer teammates in a single message** — one Agent call
 
 **Note:** `--check-base` runs at orchestrate startup and before each phase dispatch (multi-phase). No separate dispatch-level base check is needed.
 
+**Known limitation — agent-memory persistence (issue #244):** Auto-provisioned teammate worktrees are created by the platform after spawn, so the orchestrator cannot run `link-agent-memory` against them before the teammate starts writing. As a result, `memory: project` writes by task-implementer teammates currently land in the auto-provisioned worktree and are lost on teammate shutdown. Subagents mode does not have this limitation (its task worktrees are orchestrator-created and linked). Until Claude Code exposes a `SubagentStart` injection point or a memory-path override, prefer subagents mode for plans where preserved agent memory matters.
+
 ## Process Completions (Push-Based)
 
 When an implementer teammate goes idle (push notification — no polling):

--- a/skills/orchestrate/dispatch-subagents.md
+++ b/skills/orchestrate/dispatch-subagents.md
@@ -13,6 +13,7 @@ MAIN_ROOT="$(git rev-parse --path-format=absolute --git-common-dir | sed 's|/\.g
 PRE_TASK_SHA=$(git -C "$PARENT_WORKTREE" rev-parse HEAD)
 git -C "$PARENT_WORKTREE" worktree add .claude/worktrees/{TASK_ID_LOWER} -b {TASK_ID_LOWER} HEAD
 TASK_WORKTREE="$PARENT_WORKTREE/.claude/worktrees/{TASK_ID_LOWER}"
+link-agent-memory "$TASK_WORKTREE"  # symlink .claude/agent-memory → $MAIN_ROOT so memory: project subagents persist across worktree cleanup (issue #244)
 TASK_METADATA=$(jq -c --arg id "{TASK_ID}" '[.phases[].tasks[] | select(.id == $id)][0] | del(.status)' "$PLAN_JSON")
 TASK_COMPLEXITY=$(echo "$TASK_METADATA" | jq -r '.complexity')
 REVIEWER_NEEDED=$(echo "$TASK_METADATA" | jq -r '.reviewer_needed')

--- a/tests/bin/caliper-test_bin_layout.sh
+++ b/tests/bin/caliper-test_bin_layout.sh
@@ -18,8 +18,10 @@ check() {
 
 check "bin/validate-plan exists" test -f "$REPO_ROOT/bin/validate-plan"
 check "bin/caliper-settings exists" test -f "$REPO_ROOT/bin/caliper-settings"
+check "bin/link-agent-memory exists" test -f "$REPO_ROOT/bin/link-agent-memory"
 check "bin/validate-plan is executable" test -x "$REPO_ROOT/bin/validate-plan"
 check "bin/caliper-settings is executable" test -x "$REPO_ROOT/bin/caliper-settings"
+check "bin/link-agent-memory is executable" test -x "$REPO_ROOT/bin/link-agent-memory"
 check "scripts/ directory does not exist" test ! -d "$REPO_ROOT/scripts"
 check_shebang() {
   local line
@@ -28,6 +30,7 @@ check_shebang() {
 }
 check "bin/validate-plan has bash shebang" check_shebang "$REPO_ROOT/bin/validate-plan"
 check "bin/caliper-settings has bash shebang" check_shebang "$REPO_ROOT/bin/caliper-settings"
+check "bin/link-agent-memory has bash shebang" check_shebang "$REPO_ROOT/bin/link-agent-memory"
 
 echo ""
 echo "Results: $pass passed, $fail failed"

--- a/tests/bin/caliper-test_link_agent_memory.sh
+++ b/tests/bin/caliper-test_link_agent_memory.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/bin/link-agent-memory"
+
+pass=0
+fail=0
+TMPDIR_BASE="$(mktemp -d)"
+trap 'chmod -R u+w "$TMPDIR_BASE" 2>/dev/null; rm -rf "$TMPDIR_BASE"' EXIT
+
+check() {
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "PASS: $desc"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: $desc"
+    fail=$((fail + 1))
+  fi
+}
+
+check_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "PASS: $desc"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: $desc (expected=$expected actual=$actual)"
+    fail=$((fail + 1))
+  fi
+}
+
+# Build a fresh main repo + nested worktree fixture. Returns the main-repo path,
+# canonicalized via `pwd -P` so macOS's /var → /private/var symlink does not
+# trip path-equality assertions (git rev-parse resolves to the canonical form).
+new_fixture() {
+  local raw="$TMPDIR_BASE/$1"
+  mkdir -p "$raw"
+  local fix
+  fix="$(cd "$raw" && pwd -P)"
+  git -C "$fix" init -q -b main
+  git -C "$fix" config user.email "test@example.com"
+  git -C "$fix" config user.name "test"
+  (cd "$fix" && touch .gitignore && git add .gitignore && git -c commit.gpgsign=false commit -qm "init")
+  git -C "$fix" worktree add -q "$fix/wt" -b wt-branch
+  echo "$fix"
+}
+
+# Test 1: creates symlink pointing at the main repo's agent-memory dir
+fix="$(new_fixture t1)"
+"$SCRIPT" "$fix/wt"
+check "t1: symlink created at worktree path" test -L "$fix/wt/.claude/agent-memory"
+check "t1: target dir exists in main repo" test -d "$fix/.claude/agent-memory"
+target="$(readlink -- "$fix/wt/.claude/agent-memory")"
+check_eq "t1: symlink target matches main repo path" "$fix/.claude/agent-memory" "$target"
+
+# Test 2: idempotent — second invocation is a silent no-op
+fix="$(new_fixture t2)"
+"$SCRIPT" "$fix/wt"
+"$SCRIPT" "$fix/wt"
+check "t2: idempotent (still a symlink after re-run)" test -L "$fix/wt/.claude/agent-memory"
+
+# Test 3: fails loudly when a real directory already occupies the link path
+fix="$(new_fixture t3)"
+mkdir -p "$fix/wt/.claude/agent-memory"
+if "$SCRIPT" "$fix/wt" >/dev/null 2>&1; then
+  echo "FAIL: t3: should fail when real dir exists at link path"
+  fail=$((fail + 1))
+else
+  echo "PASS: t3: fails loudly on real-dir conflict"
+  pass=$((pass + 1))
+fi
+
+# Test 4: no-op when run against the main repo itself
+fix="$(new_fixture t4)"
+"$SCRIPT" "$fix"
+check "t4: main repo unchanged (no self-symlink)" test ! -L "$fix/.claude/agent-memory"
+
+# Test 5: writes through the symlink land in the main repo
+fix="$(new_fixture t5)"
+"$SCRIPT" "$fix/wt"
+mkdir -p "$fix/wt/.claude/agent-memory/some-agent"
+echo "memory content" > "$fix/wt/.claude/agent-memory/some-agent/MEMORY.md"
+check "t5: write through symlink reaches main repo" test -f "$fix/.claude/agent-memory/some-agent/MEMORY.md"
+content="$(cat "$fix/.claude/agent-memory/some-agent/MEMORY.md" 2>/dev/null || true)"
+check_eq "t5: content preserved through symlink" "memory content" "$content"
+
+# Test 6: memory survives `git worktree remove`
+fix="$(new_fixture t6)"
+"$SCRIPT" "$fix/wt"
+mkdir -p "$fix/wt/.claude/agent-memory/agent-x"
+echo "persistent" > "$fix/wt/.claude/agent-memory/agent-x/MEMORY.md"
+git -C "$fix" worktree remove "$fix/wt" --force >/dev/null
+check "t6: main repo memory file survives worktree removal" test -f "$fix/.claude/agent-memory/agent-x/MEMORY.md"
+
+# Test 7: errors when invoked without the required argument
+if "$SCRIPT" >/dev/null 2>&1; then
+  echo "FAIL: t7: should error when invoked without arg"
+  fail=$((fail + 1))
+else
+  echo "PASS: t7: errors without arg"
+  pass=$((pass + 1))
+fi
+
+echo "---"
+echo "Passed: $pass, Failed: $fail"
+[[ "$fail" -eq 0 ]]

--- a/tests/bin/caliper-test_link_agent_memory.sh
+++ b/tests/bin/caliper-test_link_agent_memory.sh
@@ -52,7 +52,7 @@ fix="$(new_fixture t1)"
 "$SCRIPT" "$fix/wt"
 check "t1: symlink created at worktree path" test -L "$fix/wt/.claude/agent-memory"
 check "t1: target dir exists in main repo" test -d "$fix/.claude/agent-memory"
-target="$(readlink -- "$fix/wt/.claude/agent-memory")"
+target="$(readlink "$fix/wt/.claude/agent-memory")"
 check_eq "t1: symlink target matches main repo path" "$fix/.claude/agent-memory" "$target"
 
 # Test 2: idempotent — second invocation is a silent no-op
@@ -69,6 +69,18 @@ if "$SCRIPT" "$fix/wt" >/dev/null 2>&1; then
   fail=$((fail + 1))
 else
   echo "PASS: t3: fails loudly on real-dir conflict"
+  pass=$((pass + 1))
+fi
+
+# Test 3b: fails loudly when a symlink to the wrong target already exists
+fix="$(new_fixture t3b)"
+mkdir -p "$fix/wt/.claude" "$fix/other-target"
+ln -s "$fix/other-target" "$fix/wt/.claude/agent-memory"
+if "$SCRIPT" "$fix/wt" >/dev/null 2>&1; then
+  echo "FAIL: t3b: should fail when symlink points to the wrong target"
+  fail=$((fail + 1))
+else
+  echo "PASS: t3b: fails loudly on mis-targeted symlink"
   pass=$((pass + 1))
 fi
 


### PR DESCRIPTION
## Summary

Fixes #244 — subagents with `memory: project` (`task-implementer`, `implementation-reviewer`, `design-reviewer`, `plan-drafter`, `plan-reviewer`) were writing to `.claude/agent-memory/<name>/` relative to their CWD. When dispatched from a worktree, that landed in the worktree's tree and was silently destroyed on `git worktree remove`.

- Claude Code's platform owns memory I/O — the `memory:` frontmatter accepts only `user` | `project` | `local` scopes with fixed paths; verified via the docs there is no override. Intercept at worktree creation instead: symlink `<worktree>/.claude/agent-memory` → `$MAIN_ROOT/.claude/agent-memory` so the platform's reads and writes transparently land in the main repo.
- New `bin/link-agent-memory` helper (idempotent; fails loudly on real-dir conflict so any stranded memory isn't silently destroyed) is wired into all three plugin-controlled worktree creation sites: `dispatch-subagents.md` (task worktrees), `orchestrate/SKILL.md` (phase worktrees — also makes the phase `git worktree add` command explicit, which was previously implicit), and `design/SKILL.md` (feature worktrees).
- Agent-teams mode's auto-provisioned teammate worktrees are platform-created post-spawn, so the orchestrator can't pre-link them. Documented as a known limitation in `dispatch-agent-teams.md` directing users to subagents mode when memory matters.

## Test plan

- [x] New `tests/bin/caliper-test_link_agent_memory.sh` — 7 cases, 10 assertions: symlink creation, idempotency, real-dir conflict refusal, main-repo no-op, write propagation, survival across `git worktree remove`, arg validation. All pass.
- [x] `tests/bin/caliper-test_bin_layout.sh` updated to register the new binary. All pass.
- [x] Full local test suite (29 scripts) — zero failures.
- [x] Implementation-review pass: 0 issues found, all five affected agents traced to dispatch sites, wiring verified consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added agent memory linking functionality for seamless memory persistence across worktrees.

* **Documentation**
  * Updated skill workflows to integrate memory linking in agent team and subagent dispatching procedures.
  * Added known limitation note regarding agent memory persistence in auto-provisioned worktrees.

* **Chores**
  * Bumped marketplace plugin versions (claude-caliper, claude-caliper-workflow, claude-caliper-tooling) to 1.44.0.

* **Tests**
  * Added comprehensive test coverage for memory linking functionality and updated binary validation tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikhilsitaram/claude-caliper/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->