### PR TITLE
feat(pr-review): post reviewer findings as inline review comments

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.44.0",
+      "version": "1.45.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -33,7 +33,7 @@
     {
       "name": "claude-caliper-workflow",
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
-      "version": "1.44.0",
+      "version": "1.45.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -56,7 +56,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit and skill evaluation",
-      "version": "1.44.0",
+      "version": "1.45.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -74,12 +74,17 @@ Subagent posts findings as inline review comments via the GitHub reviews API, th
 - Bot rate-limit warning = treat as ready.
 - Timeout: `caliper-settings get review_wait_minutes` (default: 5).
 
-**Collect from all three sources:**
+**Collect from all three sources, dropping self-authored entries.** The Step 4 reviewer subagent runs under the same gh identity as the parent and posts to sources 2-3, so re-ingesting its own findings would double-count against the Findings table returned in Step 6. Capture the identity once, then filter:
+
+```bash
+GH_USER=$(gh api user -q .login)
+```
+
 1. Conversation comments: `gh pr view --json comments`
 2. Inline review comments: `gh api repos/{owner}/{repo}/pulls/$PR_NUMBER/comments`
 3. Reviews: `gh pr view --json reviews`
 
-All three required — bots post to sources 2-3.
+Drop entries where `user.login == $GH_USER` from each source before categorizing. After filtering, sources 2-3 are bot-only.
 
 **Categorize:**
 

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -84,7 +84,13 @@ GH_USER=$(gh api user -q .login)
 2. Inline review comments: `gh api repos/{owner}/{repo}/pulls/$PR_NUMBER/comments`
 3. Reviews: `gh pr view --json reviews`
 
-Drop entries where `user.login == $GH_USER` from each source before categorizing. After filtering, sources 2-3 are bot-only.
+The author field shape differs by API — `gh pr view --json` reshapes to `.author.login` (sources 1 and 3), while the raw REST endpoint uses `.user.login` (source 2). Filter with a fallback so one expression works on all three:
+
+```bash
+jq --arg me "$GH_USER" '[.[] | select((.user.login // .author.login) != $me)]'
+```
+
+After filtering, sources 2-3 are bot-only.
 
 **Categorize:**
 

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -61,6 +61,7 @@ Read `reviewer-prompt.md` and dispatch with `run_in_background: true`:
 - `{DIFF_RANGE}` = `origin/$BASE_BRANCH...HEAD` (three-dot — merge-base diff, matches GitHub's PR view; two-dot includes phantom-reverts of base commits when the branch is behind)
 - `{REPO_PATH}` = repository root
 - `{PR_NUMBER}` = PR number
+- `{HEAD_SHA}` = `git rev-parse HEAD` — anchors the review to the exact commit the subagent saw, so line numbers stay valid even if anything pushes during the background window
 
 Subagent posts findings as inline review comments via the GitHub reviews API, then returns the Findings table for Step 6.
 

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -62,7 +62,7 @@ Read `reviewer-prompt.md` and dispatch with `run_in_background: true`:
 - `{REPO_PATH}` = repository root
 - `{PR_NUMBER}` = PR number
 
-Subagent posts findings as `gh pr comment`, then returns them for Step 6.
+Subagent posts findings as inline review comments via the GitHub reviews API, then returns the Findings table for Step 6.
 
 ### Step 5: External Feedback
 

--- a/skills/pr-review/reviewer-prompt.md
+++ b/skills/pr-review/reviewer-prompt.md
@@ -48,14 +48,55 @@ Agent tool (general-purpose):
 
     ## Post Review
 
-    After completing your review, post your full findings (the table and summary
-    above) as a comment on the PR using gh pr comment {PR_NUMBER}.
+    Post each finding as an inline review comment on the specific file
+    and line via the GitHub reviews API. Each finding becomes a
+    separately-resolvable thread, so a follow-up wave can dismiss
+    individual items without re-touching unrelated ones.
 
-    This creates a visible audit trail on the PR regardless of session state.
+    Build one JSON payload covering every finding, then submit a single
+    review:
+
+    cd {REPO_PATH}
+
+    cat > /tmp/pr_review_{PR_NUMBER}.json <<'JSON'
+    {
+      "event": "COMMENT",
+      "body": "<Summary section: counts, severity, recommendation>\n\n_— pr-review reviewer subagent_",
+      "comments": [
+        {"path": "src/foo.ts", "line": 42, "body": "**[bug]** Off-by-one in loop bound..."},
+        {"path": "src/bar.ts", "start_line": 17, "line": 19, "body": "**[logic]** Branch unreachable..."}
+      ]
+    }
+    JSON
+
+    gh api repos/{owner}/{repo}/pulls/{PR_NUMBER}/reviews \
+      --method POST --input /tmp/pr_review_{PR_NUMBER}.json
+
+    The `{owner}` and `{repo}` placeholders are filled by gh from the
+    current repo — that's why the `cd` matters. Omitting `commit_id`
+    anchors the review to the PR's most recent commit, which is correct
+    because pr-review rebased and force-pushed just before dispatching
+    this review.
+
+    Inline-comment rules:
+    - `path` is repo-root-relative (matches the diff header)
+    - `line` is the line in the file's new content (RIGHT side); add
+      `"side": "LEFT"` only when commenting on deleted code
+    - Multi-line range: set `start_line` and `line` (end) on the same side
+    - Line must be inside a diff hunk. If a finding can't anchor to a
+      changed line, list it in the review `body` instead of as an inline
+      comment
+    - Zero findings: post a review with `body: "No issues found\n\n_— pr-review reviewer subagent_"` and `comments: []`
+    - If the API rejects the payload (e.g., 422 line-not-in-diff), fall
+      back to a single `gh pr comment {PR_NUMBER}` containing the full
+      Findings table
+
+    The same findings still appear in your Findings table above — the
+    table is what the parent uses for wave dedupe.
 
     ## Rules
 
-    - Read-only review — do not modify files (except the PR comment)
+    - Read-only review — do not modify files. Posting the inline review is the only write.
     - Be specific: file:line references, not vague suggestions
     - If zero issues, say so — do not invent problems
     - Do not review test coverage or commit messages — out of scope

--- a/skills/pr-review/reviewer-prompt.md
+++ b/skills/pr-review/reviewer-prompt.md
@@ -53,30 +53,30 @@ Agent tool (general-purpose):
     separately-resolvable thread, so a follow-up wave can dismiss
     individual items without re-touching unrelated ones.
 
-    Build one JSON payload covering every finding, then submit a single
-    review:
+    From {REPO_PATH}, build one JSON payload of this shape covering every
+    finding (write it to a tmp file using whatever method handles your
+    finding-body escaping safely — e.g., `jq -n`, `python -c`, or a
+    column-0 heredoc):
 
-    cd {REPO_PATH}
-
-    cat > /tmp/pr_review_{PR_NUMBER}.json <<'JSON'
     {
       "event": "COMMENT",
-      "body": "<Summary section: counts, severity, recommendation>\n\n_— pr-review reviewer subagent_",
+      "body": "<Summary section: counts, severity, recommendation>",
       "comments": [
         {"path": "src/foo.ts", "line": 42, "body": "**[bug]** Off-by-one in loop bound..."},
         {"path": "src/bar.ts", "start_line": 17, "line": 19, "body": "**[logic]** Branch unreachable..."}
       ]
     }
-    JSON
+
+    Then POST it:
 
     gh api repos/{owner}/{repo}/pulls/{PR_NUMBER}/reviews \
-      --method POST --input /tmp/pr_review_{PR_NUMBER}.json
+      --method POST --input <path-to-json>
 
     The `{owner}` and `{repo}` placeholders are filled by gh from the
-    current repo — that's why the `cd` matters. Omitting `commit_id`
-    anchors the review to the PR's most recent commit, which is correct
-    because pr-review rebased and force-pushed just before dispatching
-    this review.
+    current repo, so run from {REPO_PATH}. Omitting `commit_id` anchors
+    the review to the PR's most recent commit, which is correct because
+    pr-review rebased and force-pushed just before dispatching this
+    review.
 
     Inline-comment rules:
     - `path` is repo-root-relative (matches the diff header)
@@ -86,7 +86,8 @@ Agent tool (general-purpose):
     - Line must be inside a diff hunk. If a finding can't anchor to a
       changed line, list it in the review `body` instead of as an inline
       comment
-    - Zero findings: post a review with `body: "No issues found\n\n_— pr-review reviewer subagent_"` and `comments: []`
+    - Zero findings: post a review with `body: "No issues found"` and
+      `comments: []`
     - If the API rejects the payload (e.g., 422 line-not-in-diff), fall
       back to a single `gh pr comment {PR_NUMBER}` containing the full
       Findings table

--- a/skills/pr-review/reviewer-prompt.md
+++ b/skills/pr-review/reviewer-prompt.md
@@ -59,6 +59,7 @@ Agent tool (general-purpose):
     column-0 heredoc):
 
     {
+      "commit_id": "{HEAD_SHA}",
       "event": "COMMENT",
       "body": "<Summary section: counts, severity, recommendation>",
       "comments": [
@@ -73,10 +74,10 @@ Agent tool (general-purpose):
       --method POST --input <path-to-json>
 
     The `{owner}` and `{repo}` placeholders are filled by gh from the
-    current repo, so run from {REPO_PATH}. Omitting `commit_id` anchors
-    the review to the PR's most recent commit, which is correct because
-    pr-review rebased and force-pushed just before dispatching this
-    review.
+    current repo, so run from {REPO_PATH}. `commit_id` is pinned to the
+    SHA pr-review captured when dispatching this review, so the line
+    numbers in your comments stay valid even if a wave-1 fix pushes
+    while you're running.
 
     Inline-comment rules:
     - `path` is repo-root-relative (matches the diff header)

--- a/skills/pr-review/reviewer-prompt.md
+++ b/skills/pr-review/reviewer-prompt.md
@@ -97,7 +97,7 @@ Agent tool (general-purpose):
 
     ## Rules
 
-    - Read-only review — do not modify files. Posting the inline review is the only write.
+    - Read-only — posting the inline review is the only write
     - Be specific: file:line references, not vague suggestions
     - If zero issues, say so — do not invent problems
     - Do not review test coverage or commit messages — out of scope


### PR DESCRIPTION
## Summary

- Switch the pr-review reviewer subagent from posting one top-level `gh pr comment` to posting batched inline review comments via the GitHub reviews API. Each finding becomes a separately-resolvable thread, so wave-2 dedupe in Step 6 operates at finding-granularity instead of "we already handled the whole comment."
- Add author-identity filtering to Step 5's external-feedback collection so the parent doesn't re-ingest the subagent's own posts as external feedback (the subagent runs under the same `gh` identity and posts to sources 2-3 of the collection).
- Reviewer-prompt shows the JSON payload shape as JSON (not a bash heredoc) — the heredoc form had an indentation footgun where the closing delimiter would be indented along with the body and never recognized by bash. Reviewer chooses jq / python / column-0 heredoc to serialize.

Inspired by the built-in `/code-review` skill's inline-comment behavior. Kept the existing reviewer-prompt focus (bug / security / logic / cleanup) and the background-dispatch shape — only the posting mechanism changes.

## Test plan

- [x] All 28 bash tests pass (`tests/**/*.sh` excluding fixtures).
- [ ] End-to-end: dispatch the updated reviewer prompt against this PR and verify inline review comments appear in the GitHub UI as separate threads, the review body lands in `/pulls/{n}/reviews`, and the author-filter rule in Step 5 would correctly drop the reviewer's own posts.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated three plugins to version 1.45.0

* **Bug Fixes / Workflow**
  * PR review flow now posts findings as inline review comments for clearer organization
  * External feedback collection now filters out bot self-authored entries to avoid duplicates and improve accuracy

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikhilsitaram/claude-caliper/pull/247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->