### PR TITLE
fix(hooks): add required `command` field so hooks load on Claude Code 2.1.x

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,14 +5,14 @@
         "matcher": "Bash",
         "hooks": [{
           "type": "command",
-          "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse-deny-patterns.sh"]
+          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse-deny-patterns.sh\""
         }]
       },
       {
         "matcher": "Edit|Write|MultiEdit",
         "hooks": [{
           "type": "command",
-          "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse-deny-plan-md.sh"]
+          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse-deny-plan-md.sh\""
         }]
       }
     ],
@@ -21,14 +21,14 @@
         "matcher": "Read|Glob|Grep|Skill|WebFetch|WebSearch|ToolSearch|Bash",
         "hooks": [{
           "type": "command",
-          "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-allow.sh"]
+          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-allow.sh\""
         }]
       },
       {
         "matcher": "Edit|Write",
         "hooks": [{
           "type": "command",
-          "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-accept-edits.sh"]
+          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-accept-edits.sh\""
         }]
       }
     ]


### PR DESCRIPTION
## What

Each command hook in `hooks/hooks.json` specifies `args` but omits the required `command` field. On Claude Code **2.1.168** all four hooks fail schema validation —

```
expected string, received undefined
  → hooks.PreToolUse[0].hooks[0].command   (and [1], PermissionRequest[0], [1])
```

— and are dropped, so the plugin's `PreToolUse` / `PermissionRequest` guardrails silently never run.

Per the [hooks reference](https://code.claude.com/docs/en/hooks.md), a `"type": "command"` hook **requires** `command` to be a string; `args` is optional (exec form) and does not replace it.

Closes #248.

## Change

Give each of the four entries a string `command` (shell form) — 4-line diff, no script changes:

```diff
-          "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse-deny-patterns.sh"]
+          "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse-deny-patterns.sh\""
```

## Why shell form rather than the docs-preferred exec form

The docs say *"prefer exec form for any hook that references a path placeholder"* — but that preference is purely about quoting ergonomics for paths with spaces (*"paths with spaces … need no quoting"*), which is already handled here by double-quoting the placeholder, exactly as the docs' own shell-form example does. Meanwhile shell form is the universal form every other plugin (including Anthropic's official ones) ships, and exec-form *runtime* support isn't guaranteed across the CC versions your users run: the validation error only proves `command` is *required*, not that `args` is *honored at runtime*, and guessing wrong there fails **silently** (bare `bash` reading the hook JSON off stdin, no error). So shell form is the safe, universally-compatible choice. Exec form — `"command": "bash", "args": [...]` — is of course fine if you'd prefer it.

## Testing

- `jq empty hooks/hooks.json` passes.
- Applied the identical change to the installed plugin and confirmed via `/reload-plugins` (loaded hook count went 3 → 7, i.e. the 4 caliper hooks now load) and `/doctor` (the "Hook load failed" error is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated hook configuration for internal tool execution system to use an improved command-based structure, replacing the previous array-based format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->