### PR TITLE
feat(implementation-review): support standalone diff-only reviews

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.45.0",
+      "version": "1.46.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -33,7 +33,7 @@
     {
       "name": "claude-caliper-workflow",
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
-      "version": "1.45.0",
+      "version": "1.46.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -56,7 +56,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit and skill evaluation",
-      "version": "1.45.0",
+      "version": "1.46.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/agents/implementation-reviewer.md
+++ b/agents/implementation-reviewer.md
@@ -9,13 +9,18 @@ effort: medium
 background: true
 ---
 
-You are performing a review of an entire feature implementation.
-Per-task reviews have passed. Your job: find issues that only become visible
-when looking at ALL tasks together.
+You are performing a holistic review of an entire feature implementation —
+the work of a caliper plan, or simply the diff on a branch. Your job: find
+issues that only become visible when looking at the change as a whole, across
+component and task boundaries — not within a single file.
+
+If the prompt supplies no plan, task list, or design doc, review the diff on
+its own merits; the categories below still apply (category 8 self-skips when
+the design doc is "None").
 
 ## Cross-Task Issue Categories
 
-Hunt for issues that span task boundaries:
+Hunt for issues that span task or component boundaries:
 
 1. **Cross-task inconsistencies** -- values that should match but don't (ports, URLs, defaults), naming drift, contradictory behavior assumptions
 

--- a/skills/implementation-review/SKILL.md
+++ b/skills/implementation-review/SKILL.md
@@ -1,68 +1,91 @@
 ---
 name: implementation-review
-description: Use when a multi-task implementation is complete and ready for holistic review before merging
+description: Use when a multi-task implementation is complete and ready for holistic review before merging, or asked to review the current branch/diff as a whole
 ---
 
 # Implementation Review
 
 Per-task reviews verify each piece works. This review verifies the pieces work **together**.
 
+## Two Modes
+
+| Mode | When | Source of truth |
+|------|------|-----------------|
+| **Caliper** | A caliper plan drove the work (orchestrate auto-dispatches, or the user points at a `plan.json`) | plan.json + phase/completion docs + design doc |
+| **Standalone** | No caliper plan exists — manual `/implementation-review`, or "review the whole branch/diff" | The git diff alone |
+
+Detect the mode: if a caller supplied a `PLAN_DIR`/`plan.json` (orchestrate context), or the user explicitly references one, run **caliper mode**. Otherwise run **standalone mode** — don't hunt for a stale plan to attach.
+
 ## When to Use
 
-- After all tasks complete in orchestrate (auto-dispatched)
-- Before merging any multi-task feature branch
-- Between phases of a multi-phase plan (auto-dispatched by orchestrate after each phase)
-- When asked to "review the whole thing" or "review everything"
+- After all tasks complete in orchestrate (caliper, auto-dispatched)
+- Between phases of a multi-phase plan (caliper, auto-dispatched by orchestrate after each phase)
+- Before merging any feature branch — with or without a plan
+- When asked to "review the whole thing", "review everything", or "review the current diff"
+
+Skip if: single-module change or purely additive work with no cross-component interactions.
 
 ## Pre-Flight Checks
 
 Before dispatching the reviewer:
 
-1. **Run integration tests** — The first task's broad acceptance tests and boundary tests at cross-task seams should all pass. If any fail, fix before proceeding.
-2. **Fill gaps** — if any cross-task boundary lacks an executable (non-mocking) test, write one now. Don't dispatch the reviewer until this passes; the reviewer's category-7 non-dismissibility rule will flag the gap as Important and trigger a re-dispatch loop.
+1. **Run integration tests** — broad acceptance tests and boundary tests at cross-component seams should pass. If any fail, fix before proceeding.
+2. **Fill gaps** — if any cross-component boundary lacks an executable (non-mocking) test, write one now. Don't dispatch until it passes; the reviewer's category-7 non-dismissibility rule will flag the gap as Important and trigger a re-dispatch loop.
 
-Skip if: single-module change or purely additive tasks with no interactions.
+## Resolve the Diff Range
+
+The reviewer needs `BASE_SHA..HEAD_SHA` covering **all** the work under review.
+
+**Caliper mode:** `BASE_SHA` is the phase start (`PHASE_BASE_SHA` from orchestrate) for phase-scoped reviews, or `PLAN_BASE_SHA` for the final review — not `git merge-base`. `HEAD_SHA` is `git rev-parse HEAD`.
+
+**Standalone mode:** derive the branch's merge-base with the default branch.
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
+git fetch origin
+BASE_SHA=$(git merge-base "origin/$DEFAULT_BRANCH" HEAD)
+HEAD_SHA=$(git rev-parse HEAD)
+```
+
+If `git diff HEAD` is non-empty there are uncommitted changes the range won't cover — tell the user to commit (or stash) them first, since the reviewer reads committed history.
 
 ## How to Dispatch
 
 Use `subagent_type: "claude-caliper:implementation-reviewer"` with the invocation template in `./reviewer-prompt.md`. The agent's static behavior (8-category cross-task checklist, output format) is in the agent definition.
 
-Template variables:
+**Use `model: "$IMPL_REVIEWER_MODEL"`** — review requires strong reasoning to catch subtle cross-component issues.
 
-| Variable | Value |
-|----------|-------|
-| `{BASE_SHA}` | Phase start SHA (`PHASE_BASE_SHA` from orchestrate) — scopes diff to current phase only |
-| `{HEAD_SHA}` | `git rev-parse HEAD` — current tip |
-| `{FEATURE_SUMMARY}` | What the feature does (1-2 sentences) |
-| `{TASK_LIST}` | Extract from plan.json: `jq '.phases[N].tasks[] \| .id + ": " + .name'` |
-| `{PLAN_DIR}` | Path to plan directory |
-| `{PHASE_DIR}` | Path to current phase directory |
-| `{REPO_PATH}` | Repository root path |
-| `{PHASE_CONTEXT}` | Phase letter and name (e.g., "Phase A of C: Core API"), and what downstream phases expect (interfaces, config, APIs). Empty string for final/single-phase reviews. |
-| `{DESIGN_DOC_PATH}` | Path to design doc (from plan frontmatter, or "None") |
+Fill the template variables:
 
-**Use `model: "$IMPL_REVIEWER_MODEL"`** — review requires strong reasoning to catch subtle cross-task issues.
+| Variable | Caliper mode | Standalone mode |
+|----------|--------------|-----------------|
+| `{BASE_SHA}` / `{HEAD_SHA}` | Phase/plan range (above) | merge-base range (above) |
+| `{REPO_PATH}` | Repository root path | Repository root path |
+| `{FEATURE_SUMMARY}` | What the feature does (1-2 sentences) | What the branch does — infer from commits/diff, or ask the user |
+| `{TASK_LIST}` | `jq '.phases[N].tasks[] \| .id + ": " + .name'` | Omit — the prompt drops this section |
+| `{PLAN_DIR}` / `{PHASE_DIR}` | Plan and phase directory paths | Omit — the prompt drops these |
+| `{PHASE_CONTEXT}` | Phase letter/name + downstream expectations (empty for final/single-phase) | Empty |
+| `{DESIGN_DOC_PATH}` | Path from plan frontmatter (or "None") | "None" — disables success-criteria category 8 |
 
-**Use the full diff range** — `BASE_SHA..HEAD_SHA` must cover ALL tasks, not just the last one.
-
-**Phase-scoped reviews:** For inter-phase reviews, `BASE_SHA` is the commit before the phase's first task — not `git merge-base origin/main`. This scopes the diff to only the current phase's changes.
+The reviewer's first 7 categories (cross-component consistency, duplication, dead code, docs, errors, integration gaps, test coverage) run identically in both modes against the diff. Only category 8 (success-criteria fulfillment) and plan-doc bookkeeping are caliper-only.
 
 ## What It Catches
 
 | Category | Example |
 |----------|---------|
-| Cross-task inconsistency | Config says port 3000, README says 8080 |
+| Cross-component inconsistency | Config says port 3000, README says 8080 |
 | Duplicated constants | Same timeout defined in two modules |
 | Code duplication | Identical function in two files |
 | Dead code from iteration | Conditional where both branches are identical |
 | Documentation gaps | Feature supported but undocumented |
 | Inconsistent errors | Same generic error from multiple locations |
 | Missing boundary tests | Components interact but no integration test |
-| Unmet success criteria | Design says "users can X" but implementation doesn't deliver it |
+| Unmet success criteria | Design says "users can X" but implementation doesn't deliver it (caliper only) |
 
-## Post-Review: Plan Doc Updates
+## Post-Review: Plan Doc Updates (caliper only)
 
-After review passes, the **orchestrator** updates the plan document:
+After review passes, the **orchestrator** updates the plan document. Skip this entirely in standalone mode.
 
 1. **Document fixups** — append `### Implementation Review Changes` to `phase-{letter}/completion.md` listing each change. Omit if no fixups needed.
 
@@ -70,12 +93,14 @@ After review passes, the **orchestrator** updates the plan document:
 
 ## Re-Review Gate
 
-Read the threshold: `caliper-settings get re_review_threshold` (default: 5). If the reviewer finds more issues than this threshold: after all fixes are applied, dispatch a fresh reviewer subagent with the same full review scope. This catches reviewer hallucination from compounding and new issues introduced by bulk fixes.
+Applies in both modes. Read the threshold: `caliper-settings get re_review_threshold` (default: 5). If the reviewer finds more issues than this threshold: after all fixes are applied, dispatch a fresh reviewer subagent with the same full review scope. This catches reviewer hallucination from compounding and new issues introduced by bulk fixes.
 
-At or under the threshold, the orchestrator verifies fixes and proceeds without re-review.
+At or under the threshold, verify fixes and proceed without re-review.
 
 ## Integration
 
-**Auto-dispatched by:** orchestrate (after all tasks complete)
+**Auto-dispatched by:** orchestrate (caliper mode, after all tasks complete)
+
+**Invoked manually:** `/implementation-review` on any branch (standalone mode)
 
 **Leads to:** pr-create (once review passes)

--- a/skills/implementation-review/reviewer-prompt.md
+++ b/skills/implementation-review/reviewer-prompt.md
@@ -2,17 +2,19 @@
 
 Use this template when dispatching an implementation-reviewer agent. The agent's static behavior (8-category cross-task checklist, integration test coverage, output format, review-summary format) is defined in the `claude-caliper:implementation-reviewer` agent definition. This template provides only the dynamic per-invocation context.
 
+The template works for both **caliper mode** (a plan drove the work) and **standalone mode** (diff-only review of a branch). In standalone mode, omit the caliper-only sections — see "Standalone mode" below.
+
 ## Variables
 
-- `{FEATURE_SUMMARY}` — what the feature does (1-2 sentences)
-- `{TASK_LIST}` — extracted from plan.json: `jq '.phases[N].tasks[] | .id + ": " + .name'`
+- `{FEATURE_SUMMARY}` — what the feature/branch does (1-2 sentences)
+- `{TASK_LIST}` — extracted from plan.json: `jq '.phases[N].tasks[] | .id + ": " + .name'` (caliper only)
 - `{REPO_PATH}` — repository root path
-- `{BASE_SHA}` — phase start SHA (scopes diff to current phase)
+- `{BASE_SHA}` — caliper: phase/plan start SHA. Standalone: `git merge-base origin/<default> HEAD`
 - `{HEAD_SHA}` — current tip (`git rev-parse HEAD`)
-- `{PLAN_DIR}` — path to plan directory
-- `{PHASE_DIR}` — path to current phase directory
-- `{PHASE_CONTEXT}` — phase letter/name and downstream expectations (empty for final/single-phase)
-- `{DESIGN_DOC_PATH}` — path to design doc (or "None")
+- `{PLAN_DIR}` — path to plan directory (caliper only)
+- `{PHASE_DIR}` — path to current phase directory (caliper only)
+- `{PHASE_CONTEXT}` — phase letter/name and downstream expectations (empty for final/single-phase; caliper only)
+- `{DESIGN_DOC_PATH}` — path to design doc, or "None" (always "None" in standalone mode)
 - `{IMPL_REVIEWER_MODEL}` — model for the reviewer agent (from caliper-settings)
 
 ## Dispatch Example
@@ -56,3 +58,38 @@ Agent(
     Read {PHASE_DIR}/completion.md for completion summary and deviations."
 )
 ```
+
+## Standalone Mode
+
+When no caliper plan drove the work, drop the plan-derived sections — the diff is the only source of truth. The prompt collapses to:
+
+```text
+Agent(
+  subagent_type: "claude-caliper:implementation-reviewer",
+  model: "{IMPL_REVIEWER_MODEL}",
+  prompt: "Review the complete branch implementation.
+
+    ## Summary
+
+    {FEATURE_SUMMARY}
+
+    ## Git Range
+
+    The code is at {REPO_PATH}
+
+    git diff --stat {BASE_SHA}..{HEAD_SHA}
+    git diff {BASE_SHA}..{HEAD_SHA}
+
+    Read every file in the diff.
+
+    ## Design Doc
+
+    None.
+
+    ## Phase Context
+
+    (none — single standalone review)"
+)
+```
+
+The reviewer runs categories 1–7 against the diff. Category 8 (success-criteria fulfillment) self-skips because the design doc is "None".


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Support standalone diff-only mode for implementation-review dispatch
<code>✨ Enhancement</code> <code>📝 Documentation</code> <code>⚙️ Configuration changes</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary
- `implementation-review` now runs in two modes: **caliper** (a plan drove the work — orchestrate auto-dispatches with full plan/phase/design context, unchanged) and **standalone** (no plan — manual `/implementation-review` or "review the current diff").
- Standalone mode derives the diff range from `git merge-base origin/<default> HEAD` and reviews the diff alone; warns if uncommitted changes fall outside the range.
- Reviewer agent needed only a light touch — categories 1–7 are already diff-driven, and category 8 (success-criteria) self-skips when the design doc is "None". Added a standalone dispatch variant to the prompt template that drops plan-derived sections.
- Plan-doc bookkeeping is gated to caliper mode; the re-review gate applies in both.
- Bumped marketplace version 1.45.0 → 1.46.0.

## Test plan
- Markdown/skill-definition change only; no executable tests in this repo for the skill. Manual review of the two-mode dispatch logic and conditional prompt sections.

Co-Authored-By: Claude <noreply@anthropic.com>

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add standalone (no-plan) mode for diff-only holistic implementation reviews.
• Define merge-base derived git range and guardrails for uncommitted changes.
• Update reviewer prompt/agent docs; gate plan-doc bookkeeping to caliper mode.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
flowchart TD
  A["User / Orchestrate"] --> B{"Mode select"} --> C(["Review skill"]) --> D["reviewer-prompt.md"] --> E(["Reviewer agent"])
  C --> F{{"Git (merge-base/diff)"}} & G[/"Plan docs"/]

  subgraph Legend
    direction LR
    _usr["Caller"] ~~~ _svc(["Skill/Agent"]) ~~~ _file[["Template file"]] ~~~ _ext{{"External"}} ~~~ _doc[/"Docs"/]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Require explicit BASE_SHA/HEAD_SHA for standalone</b></summary>

- ➕ Avoids ambiguity when branches contain merge commits or unusual histories
- ➕ Lets callers scope reviews to a specific subset of commits intentionally
- ➖ More user friction for the common case
- ➖ Higher chance of user error (wrong range) leading to incomplete reviews

</details>

<details>
<summary><b>2. Use triple-dot diff semantics (origin/default...HEAD)</b></summary>

- ➕ Directly expresses “changes introduced on this branch” in git terminology
- ➕ Often matches merge-base behavior without requiring separate merge-base computation
- ➖ Can be less explicit for users unfamiliar with ... semantics
- ➖ Still needs clear handling/communication for local uncommitted changes

</details>

**Recommendation:** The PR’s approach (standalone = merge-base-derived BASE..HEAD plus an explicit warning about uncommitted work) is the best default: it’s low-friction, review-complete for typical branch workflows, and keeps caliper plan bookkeeping cleanly gated. If reviewers report confusion about range selection, consider adding an optional override to supply BASE/HEAD explicitly or switching the documentation to show origin/...HEAD.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>SKILL.md</strong> <code>Document caliper vs standalone modes and diff-range resolution</code> <code>+56/-31</code></summary>

<br/>

>Document caliper vs standalone modes and diff-range resolution
>
><pre>
>• Introduces two operational modes (caliper vs standalone) and defines how to detect them. Adds explicit instructions for deriving BASE_SHA via merge-base in standalone mode, handling uncommitted changes, and gating plan-doc updates to caliper mode while keeping the re-review gate for both.
></pre>
>
><a href='https://github.com/nikhilsitaram/claude-caliper/pull/250/files#diff-19dbba70623a94faff0fb0c05c84f664d5e18d1504a0c7db39bb21d0c86b2578'>skills/implementation-review/SKILL.md</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>implementation-reviewer.md</strong> <code>Clarify reviewer agent works with plan-backed or diff-only context</code> <code>+9/-4</code></summary>

<br/>

>Clarify reviewer agent works with plan-backed or diff-only context
>
><pre>
>• Reframes the agent’s mission as a holistic cross-component review that may be plan-driven or purely diff-driven. Adds guidance that categories still apply without a plan and that success-criteria self-skips when design doc is None.
></pre>
>
><a href='https://github.com/nikhilsitaram/claude-caliper/pull/250/files#diff-88292bb5c1ae03a2109b6c208f68c24b97f8a1914ff82af6f469134ea642abd5'>agents/implementation-reviewer.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>reviewer-prompt.md</strong> <code>Add standalone dispatch template variant without plan-derived sections</code> <code>+44/-7</code></summary>

<br/>

>Add standalone dispatch template variant without plan-derived sections
>
><pre>
>• Updates variable documentation to distinguish caliper-only fields from standalone behavior. Adds a concrete standalone-mode prompt example that supplies only feature summary and git diff range, with design doc set to None.
></pre>
>
><a href='https://github.com/nikhilsitaram/claude-caliper/pull/250/files#diff-5062e0460e056cfcebc00dd5f908a15b3b65a2ef8191f5e6a82f10f3b61493a3'>skills/implementation-review/reviewer-prompt.md</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>marketplace.json</strong> <code>Bump marketplace bundle versions to 1.46.0</code> <code>+3/-3</code></summary>

<br/>

>Bump marketplace bundle versions to 1.46.0
>
><pre>
>• Updates claude-caliper bundle/package versions from 1.45.0 to 1.46.0 across marketplace entries. This aligns published metadata with the new standalone implementation-review capability.
></pre>
>
><a href='https://github.com/nikhilsitaram/claude-caliper/pull/250/files#diff-5352ee4067f17e7948e1425843f0a454e045bc8edf338f0bcf75c6804ddabd9a'>.claude-plugin/marketplace.json</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Caliper plugin versions (`claude-caliper`, `claude-caliper-workflow`, `claude-caliper-tooling`) to 1.46.0.

* **Documentation**
  * Enhanced implementation review documentation with clarified dual-mode support and improved dispatch instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->