### PR TITLE
fix(hooks): restore required command field in exec-form hooks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.46.0",
+      "version": "1.46.1",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -33,7 +33,7 @@
     {
       "name": "claude-caliper-workflow",
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
-      "version": "1.46.0",
+      "version": "1.46.1",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -56,7 +56,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit and skill evaluation",
-      "version": "1.46.0",
+      "version": "1.46.1",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ Bash test scripts live in `tests/`. Run with `bash tests/<dir>/<script>.sh`. Ski
 
 All shell scripts (`bin/*`, `tests/**/*.sh`) must have a `#!/usr/bin/env bash` shebang and the executable bit set (`chmod +x`). Agent teammates can't auto-approve `bash <script>` because `bash` is excluded from safe-commands — but `./script` resolves to the script's own path, which the hook can approve.
 
+In `hooks/hooks.json`, `command`-type hooks always require a `command` string — even in exec form, where `command` is the *executable* and `args` is its argument vector (e.g. `"command": "bash", "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/x.sh"]`). Putting the script path in `args` with no `command` fails schema validation (`command: expected string, received undefined`) and silently disables every hook.
+
 ## Development Workflow
 
 This repo uses its own skills. The typical flow: design -> worktree -> draft-plan -> orchestrate -> pr-create -> pr-review -> pr-merge.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,6 +5,7 @@
         "matcher": "Bash",
         "hooks": [{
           "type": "command",
+          "command": "bash",
           "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse-deny-patterns.sh"]
         }]
       },
@@ -12,6 +13,7 @@
         "matcher": "Edit|Write|MultiEdit",
         "hooks": [{
           "type": "command",
+          "command": "bash",
           "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse-deny-plan-md.sh"]
         }]
       }
@@ -21,6 +23,7 @@
         "matcher": "Read|Glob|Grep|Skill|WebFetch|WebSearch|ToolSearch|Bash",
         "hooks": [{
           "type": "command",
+          "command": "bash",
           "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-allow.sh"]
         }]
       },
@@ -28,6 +31,7 @@
         "matcher": "Edit|Write",
         "hooks": [{
           "type": "command",
+          "command": "bash",
           "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/permission-request-accept-edits.sh"]
         }]
       }


### PR DESCRIPTION
## Summary
- PR #241 migrated all four hooks to the `args` exec form but dropped the `command` field, putting the script path in `args[0]`. The exec form still requires `command` (the executable); `args` is only its argument vector.
- With `command` undefined, every hook failed schema validation (`command: expected string, received undefined`) and silently disabled — breaking caliper's deny/allow hooks for all users on CLI 2.1.139+.
- Fix: set `command` to `"bash"` and pass the script via `args`, matching the documented exec-form pattern (`command`=interpreter, `args`=`[script]`). Bump marketplace version (1.46.0 → 1.46.1) so the installer refreshes stale cache. Add a CLAUDE.md guard documenting the rule.

## Test plan
- `tests/hooks/*.sh` — 126 assertions across deny-plan-md, permission-request, and safe-commands suites, all passing.
- Validated both `hooks/hooks.json` and `.claude-plugin/marketplace.json` parse as JSON.

Note: nothing currently validates `hooks.json` against the CLI hook schema, which is why #241's bug shipped silently — a candidate follow-up.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated three plugins to version 1.46.1.

* **Documentation**
  * Added clarification on hooks schema requirements and validation.

* **Bug Fixes**
  * Fixed hook configurations to comply with schema requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->