### PR TITLE
feat(pr-review): reply inline to reviewer findings with their disposition

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.46.1",
+      "version": "1.46.2",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -33,7 +33,7 @@
     {
       "name": "claude-caliper-workflow",
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
-      "version": "1.46.1",
+      "version": "1.46.2",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -56,7 +56,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit and skill evaluation",
-      "version": "1.46.1",
+      "version": "1.46.2",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -63,7 +63,19 @@ Read `reviewer-prompt.md` and dispatch with `run_in_background: true`:
 - `{PR_NUMBER}` = PR number
 - `{HEAD_SHA}` = `git rev-parse HEAD` — anchors the review to the exact commit the subagent saw, so line numbers stay valid even if anything pushes during the background window
 
-Subagent posts findings as inline review comments via the GitHub reviews API, then returns the Findings table for Step 6.
+Subagent posts findings as inline review comments via the GitHub reviews API, then returns the Findings table (with each finding's `Comment ID`) for Step 6.
+
+### Replying to reviewer findings
+
+When you decide a subagent finding's disposition (fix or dismiss), reply in its own thread so the back-and-forth lives where the issue was raised — not only in the Step 9 summary. Reply by the `Comment ID` from the returned table:
+
+```bash
+gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/comments/$COMMENT_ID/replies" \
+  -f body="Fixed in $(git rev-parse --short HEAD) — <what changed>."
+# or: -f body="Dismissed — <technical reasoning>."
+```
+
+These are your own (`$GH_USER`) comments — replying to them is intended, and is separate from the Step 5 self-filter, which only prevents *re-ingesting* findings. Findings with `Comment ID` = `—` (body-only) have no thread; they go in the Step 9 summary instead. Post each reply where the disposition is finalized: Step 6 (automated) or Step 8 (deliberate).
 
 ### Step 5: External Feedback
 
@@ -110,7 +122,7 @@ After filtering, sources 2-3 are bot-only.
 
 Wait for background subagent (Step 4). Skip if `--skip-review`.
 
-**Automated (fix or merge):** Dismiss findings already fixed in wave 1. Fix remaining actionable items, run tests, commit and push (covers both waves).
+**Automated (fix or merge):** Dismiss findings already fixed in wave 1. Fix remaining actionable items, run tests, commit and push (covers both waves). Reply inline to each subagent finding's thread with its disposition (see Replying to reviewer findings).
 
 **Deliberate:** Merge with Step 5 findings into unified set. Proceed to Step 7.
 
@@ -124,11 +136,11 @@ Show summary table (source, category, action, counts). AskUserQuestion:
 
 ### Step 8: Fix, Test, Push (Deliberate Only)
 
-Skip if `--skip-fixes`. Fix each item, run tests (fail = stop), commit and push.
+Skip if `--skip-fixes`. Fix each item, run tests (fail = stop), commit and push. Reply inline to each subagent finding's thread with its disposition (see Replying to reviewer findings).
 
 ### Step 9: Comment on PR
 
-Post `gh pr comment`: what was fixed, dismissed (with reasons), no-action. Omit empty sections.
+Post `gh pr comment`: what was fixed, dismissed (with reasons), no-action. Omit empty sections. Subagent findings answered inline (Step 6/8) need only a roll-up count here, not a re-listing — the per-item reasoning lives in their threads. The summary still fully covers external feedback and any body-only findings that had no thread.
 
 Report PR URL and item counts. Automated-merge mode: invoke pr-merge. Automated-fix mode: tell user to run `/pr-merge` when ready. Deliberate mode: offer merge or tell user to run `/pr-merge` when ready.
 

--- a/skills/pr-review/reviewer-prompt.md
+++ b/skills/pr-review/reviewer-prompt.md
@@ -34,11 +34,15 @@ Agent tool (general-purpose):
 
     ### Findings
 
-    | # | Severity | File:Line | Finding |
-    |---|----------|-----------|---------|
+    | # | Severity | File:Line | Comment ID | Finding |
+    |---|----------|-----------|------------|---------|
+
+    Leave `Comment ID` blank until after you post (see Post Review) —
+    the parent replies to each thread by this id. Body-only and
+    fallback findings get `—`.
 
     If zero issues found, output the table header with a single row:
-    | — | — | — | No issues found |
+    | — | — | — | — | No issues found |
 
     ### Summary
 
@@ -78,6 +82,15 @@ Agent tool (general-purpose):
     SHA pr-review captured when dispatching this review, so the line
     numbers in your comments stay valid even if a wave-1 fix pushes
     while you're running.
+
+    The POST response is the review object (its `.id`), not the line
+    comments. Fetch them and map each back to a finding by path+line so
+    the parent can reply to the exact thread:
+
+    gh api repos/{owner}/{repo}/pulls/{PR_NUMBER}/reviews/<review_id>/comments
+
+    Fill the `Comment ID` column of your Findings table from each
+    comment's `.id`. Body-only and fallback findings keep `—`.
 
     Inline-comment rules:
     - `path` is repo-root-relative (matches the diff header)


### PR DESCRIPTION
## Summary
- The reviewer subagent posts findings as inline review comments, but the main context's fix/dismiss disposition only landed in the Step 9 summary block — disconnected from the threads it answered. Now each disposition is posted as a threaded reply on the originating comment.
- `reviewer-prompt.md`: Findings table gains a `Comment ID` column; after posting its review the subagent fetches the review's comments and maps each finding back to its comment id (body-only/fallback findings keep `—`).
- `SKILL.md`: new "Replying to reviewer findings" subsection with the replies-API command; Step 6 (automated) and Step 8 (deliberate) post the disposition inline where the decision is finalized; Step 9 summary now roll-ups in-thread findings instead of re-listing them. Replies target the subagent's own (`$GH_USER`) comments by id — intended, and orthogonal to the Step 5 self-filter that only blocks re-ingestion.
- Bumped marketplace version 1.46.1 → 1.46.2 (skill behavior changed).

## Test plan
- Doc-only skill changes (SKILL.md / reviewer-prompt.md prose); no automated tests cover skill prose.
- Verified `marketplace.json` remains valid JSON after the version bump.
- Replies are addressed by comment `id` (not path:line), so a wave-1 fix shifting line numbers won't misroute a reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin versions to 1.46.2 for `claude-caliper`, `claude-caliper-workflow`, and `claude-caliper-tooling`.

* **Documentation**
  * Updated PR review workflow instructions and prompt templates to improve reviewer comment handling and finding tracking processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->