### PR TITLE
feat(implementation-review): surface findings to user and add workflow-continuation flags

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.46.2",
+      "version": "1.47.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -33,7 +33,7 @@
     {
       "name": "claude-caliper-workflow",
       "description": "End-to-end development workflow: design → draft-plan → orchestrate → review → pr-create → pr-review → pr-merge",
-      "version": "1.46.2",
+      "version": "1.47.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -56,7 +56,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit and skill evaluation",
-      "version": "1.46.2",
+      "version": "1.47.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/skills/implementation-review/SKILL.md
+++ b/skills/implementation-review/SKILL.md
@@ -83,6 +83,17 @@ The reviewer's first 7 categories (cross-component consistency, duplication, dea
 | Missing boundary tests | Components interact but no integration test |
 | Unmet success criteria | Design says "users can X" but implementation doesn't deliver it (caliper only) |
 
+## Triage & Fix
+
+When the reviewer returns, **display what it found, then proceed straight to fixing — don't stop for confirmation.** This is a visibility step, not an approval gate: silently fixing and dismissing leaves the user blind to what was wrong, but waiting on a confirmation reply stalls the run. Present a compact summary — group by severity, and for each issue give its `file:line`, category, and the one-line problem — then immediately continue into the fixes below. Continuation flags don't change this: findings are always shown, fixing always proceeds without a pause.
+
+Address each:
+
+- **Fix** actionable findings — verify against the code first, since the reviewer can be wrong.
+- **Dismiss** false positives with a stated technical reason. Findings marked `non_dismissible: true` (category-7 seam-mock gaps) can't be dismissed — fix them or re-dispatch.
+
+Run the relevant tests after fixing, then apply the Re-Review Gate.
+
 ## Post-Review: Plan Doc Updates (caliper only)
 
 After review passes, the **orchestrator** updates the plan document. Skip this entirely in standalone mode.
@@ -96,6 +107,19 @@ After review passes, the **orchestrator** updates the plan document. Skip this e
 Applies in both modes. Read the threshold: `caliper-settings get re_review_threshold` (default: 5). If the reviewer finds more issues than this threshold: after all fixes are applied, dispatch a fresh reviewer subagent with the same full review scope. This catches reviewer hallucination from compounding and new issues introduced by bulk fixes.
 
 At or under the threshold, verify fixes and proceed without re-review.
+
+## Continue the Workflow
+
+By default the skill stops once the review passes and fixes land. These flags chain the next steps automatically — but only after the review fully passes (re-review gate included) and the user has seen the findings:
+
+| Flag | Effect |
+|------|--------|
+| `--pr-create` | Invoke the pr-create skill to commit, push, and open a PR. |
+| `--pr-review` | Invoke pr-create, then the pr-review skill. Forward any pr-review flags placed after it — `--automated-fix`/`-A`, `--automated-merge`/`-M`, or `--deliberate`/`-D`. |
+
+`--pr-review` with no forwarded mode flag lets pr-review select its mode the usual way (configured `review_mode`, else prompt). These flags are for manual `/implementation-review`; in caliper mode orchestrate already drives pr-create after the review.
+
+If both `--pr-create` and `--pr-review` are passed, `--pr-review` wins (it includes PR creation). If the review can't be made to pass (unresolved `non_dismissible` findings, or fixes keep failing tests), stop before the continuation rather than opening a PR on a failing review.
 
 ## Integration
 

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -23,9 +23,9 @@ If not on PR branch: use existing worktree if found (`cd` into it), otherwise `g
 
 ### Step 2: Mode Selection
 
-If `--automated-fix`/`-A` passed, use automated-fix mode. If `--automated-merge`/`-M` passed, use automated-merge mode. Both flags together is invalid — fail fast. Either automated flag + `--skip-fixes` is also invalid — fail fast.
+If `--automated-fix`/`-A` passed, use automated-fix mode. If `--automated-merge`/`-M` passed, use automated-merge mode. If `--deliberate`/`-D` passed, use deliberate mode (skip the settings lookup and prompt below). More than one mode flag together is invalid — fail fast. Either automated flag + `--skip-fixes` is also invalid — fail fast.
 
-If no flag, read the user's preference:
+If no mode flag, read the user's preference:
 
 ```bash
 mode=$(caliper-settings get review_mode)
@@ -154,6 +154,7 @@ Report PR URL and item counts. Automated-merge mode: invoke pr-merge. Automated-
 | `--skip-fixes` / `-S` | Skip fixing — just comment (invalid with automated modes) |
 | `--automated-fix` / `-A` | Fix all actionable, no interaction |
 | `--automated-merge` / `-M` | Fix all actionable, then auto-merge |
+| `--deliberate` / `-D` | Force deliberate mode — skip settings lookup and prompt |
 
 ## Pitfalls
 


### PR DESCRIPTION
## Summary

- **Display findings before fixing.** New *Triage & Fix* section in `implementation-review` makes surfacing the reviewer's findings a mandatory visibility step — present them grouped by severity (with `file:line`, category, one-line problem), then proceed straight into fixing/dismissing *without pausing for confirmation*. Previously the main context silently fixed/dismissed, leaving the user blind to what was wrong.
- **Workflow-continuation flags.** Manual `/implementation-review` can now chain the next steps once the review passes (re-review gate included):
  - `--pr-create` → invoke pr-create.
  - `--pr-review` → invoke pr-create, then pr-review, forwarding pr-review mode flags (`--automated-fix`, `--automated-merge`, `--deliberate`). Stops rather than opening a PR on an unresolvable review.
- **`--deliberate`/`-D` flag added to pr-review** so deliberate mode can be selected (and forwarded) explicitly without relying on the settings/prompt default.
- Version bump 1.46.1 → 1.47.0 across all three marketplace plugins.

## Test plan

- `find tests -name '*.sh'` suite: 28/28 real tests pass (the lone non-pass is `fixtures/gh-mock.sh`, a test fixture, not a standalone test).
- `marketplace.json` validated as JSON after the version bump.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated marketplace plugin versions to 1.47.0

* **Documentation**
  * Enhanced implementation-review skill documentation with post-review handling procedures and workflow continuation options
  * Clarified pr-review skill documentation for deliberate mode support and updated argument specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->