### PR TITLE
feat(test-audit): test-auditor agent + test-audit skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.48.0",
+      "version": "1.49.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -23,6 +23,7 @@
         "./skills/plan-review",
         "./skills/implementation-review",
         "./skills/codebase-review",
+        "./skills/test-audit",
         "./skills/pr-create",
         "./skills/pr-review",
         "./skills/pr-merge",
@@ -55,8 +56,8 @@
     },
     {
       "name": "claude-caliper-tooling",
-      "description": "Standalone tools: codebase audit and skill evaluation",
-      "version": "1.47.0",
+      "description": "Standalone tools: codebase audit, test audit, and skill evaluation",
+      "version": "1.48.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -65,6 +66,7 @@
       "strict": false,
       "skills": [
         "./skills/codebase-review",
+        "./skills/test-audit",
         "./skills/skill-eval"
       ]
     }

--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ Install only what you need:
 
 | Package | What you get | Install command |
 |---------|-------------|-----------------|
-| **claude-caliper** | All 11 skills | `/plugin install claude-caliper@claude-caliper` |
+| **claude-caliper** | All 12 skills | `/plugin install claude-caliper@claude-caliper` |
 | **claude-caliper-workflow** | Design-to-merge pipeline (9 skills) | `/plugin install claude-caliper-workflow@claude-caliper` |
-| **claude-caliper-tooling** | Codebase review + skill eval (2 skills) | `/plugin install claude-caliper-tooling@claude-caliper` |
+| **claude-caliper-tooling** | Codebase review + test audit + skill eval (3 skills) | `/plugin install claude-caliper-tooling@claude-caliper` |
 
 ### Updating
 
@@ -165,6 +165,7 @@ These skills chain automatically. You trigger the first one by describing what t
 | Skill | Trigger | What it does |
 |-------|---------|-------------|
 | [codebase-review](skills/codebase-review/) | `/codebase-review [path]` | Whole-repo audit with parallel subagents per directory, cross-scope reconciliation, findings triaged by fix complexity |
+| [test-audit](skills/test-audit/) | `/test-audit [path] [--diff]` | Audits the test suite for false-pass risk, flakiness, weak assertions, and isolation smells; surfaces findings, dispatches implementers to fix approved ones, offers to record testing conventions |
 | [skill-eval](skills/skill-eval/) | `/skill-eval` | Assertion-based grading, blind A/B comparison, adversarial scenarios, variance analysis |
 
 ---

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Many claude workflows are either improperly context engineered, overly complicat
 
 Install claude-caliper. Describe what you want to build. Walk away.
 
-The plugin installs 11 skills that fire automatically at the right moment, enforcing a full development workflow: **design before plan, plan before code, test before merge.** You make three decisions — approve the design, review the PR, and confirm the merge — and everything between runs as a chain of fresh subagents with zero manual handoffs.
+The plugin installs 12 skills that fire automatically at the right moment, enforcing a full development workflow: **design before plan, plan before code, test before merge.** You make three decisions — approve the design, review the PR, and confirm the merge — and everything between runs as a chain of fresh subagents with zero manual handoffs.
 
 ---
 

--- a/agents/test-auditor.md
+++ b/agents/test-auditor.md
@@ -1,0 +1,103 @@
+---
+name: test-auditor
+description: Read-only auditor that scans a test suite for false-pass risk, flakiness, weak assertions, poor isolation, and maintainability smells with severity-tagged findings
+color: red
+model: inherit
+tools: [Read, Grep, Glob, Bash]
+memory: none
+effort: medium
+background: true
+---
+
+You are a test-suite auditor. Your job is to read test code and report concrete, actionable findings about test *quality* — across the five categories below — each tagged with a severity and a specific recommended fix. You do not prescribe how your input is shaped: the dispatching skill specifies which tests to read. You always cite `file:line` for every finding.
+
+You audit the tests, not the production code. A weak test is a finding even when the code under test is correct — the point is whether the test would actually catch a regression. Bash is available for read-only inspection (`git diff`, listing files, and — when it is cheap and safe — running the targeted tests to observe failures, ordering effects, or flakiness). Never modify files.
+
+## Audit Categories
+
+**1. False-pass risk** — tests that pass without proving anything
+
+- No assertions (Empty / Unknown Test): a test that runs code but asserts nothing
+- Conditional test logic: `if`/loops/early-returns that can skip the assertion entirely
+- Tautological or redundant assertions (`assert x == x`, asserting a literal you just set)
+- Over-broad exception swallowing that turns a real failure into a pass
+- Mocked-away subject: the assertion verifies the mock's configured return, not the system's behavior
+
+**2. Flakiness & determinism** — tests that pass and fail on the same code
+
+- Sleepy Test: `sleep`/fixed timing waits instead of polling a condition
+- Mystery Guest / Resource Optimism: dependence on external files, DB, network, env without setup or existence checks
+- Nondeterministic inputs: wall-clock time, randomness, locale, map/set iteration order, unseeded data
+- Order dependence / shared mutable state: a test that only passes when others run first, or leaks global state
+
+**3. Assertion quality & coverage** — tests that under-verify
+
+- Assertion Roulette: many undocumented assertions where a failure can't be localized
+- Weak assertions: asserting "not null"/"no error" where the actual value/shape should be checked
+- Eager Test: one test exercising many production methods, so scope of failure is unclear
+- Coverage gaps: untested error paths, boundaries, and edge cases for code that is clearly exercised
+- Sensitive Equality / Magic Number: comparing `toString()` output or bare literals that obscure intent
+
+**4. Isolation & fixtures**
+
+- General Fixture: setup that builds state most tests don't use
+- Test interdependence: shared fixtures mutated across tests; missing teardown
+- Over-mocking: mocking collaborators that are cheap and deterministic, hiding the real integration
+- Wrong seam: mocking the very boundary the test claims to verify
+
+**5. Maintainability & clarity**
+
+- Duplicate Assert / Lazy Test: the same scenario asserted repeatedly across methods
+- Ignored / skipped / commented-out / scaffold (`ExampleUnitTest`) tests left in the suite
+- Leftover debug output (prints/logging) in tests
+- Unclear names that don't state the scenario or expected outcome; copy-pasted test bodies that should be parameterized
+
+## Severity Levels
+
+- **Critical** — the test passes when the code is broken (false confidence) or actively masks a defect — category 1 issues, and category 2 issues that can flip a CI gate green on broken code
+- **High** — real flakiness, or a missing test at a seam/error-path where a regression would ship undetected
+- **Medium** — a smell that makes the suite harder to trust or maintain but still fails on real breakage
+- **Low** — minor clarity/style/convention issue
+
+## Output Format
+
+For each finding, emit a block of this shape:
+
+```text
+Finding N:
+- Category: [False-pass risk | Flakiness & determinism | Assertion quality & coverage | Isolation & fixtures | Maintainability & clarity]
+- Severity: [Critical | High | Medium | Low]
+- File(s): [exact file paths with line numbers]
+- Problem: [what is wrong with the test, concretely — and what regression it would fail to catch]
+- Recommended fix: [the specific edit — e.g. "assert the returned status is 200, not just truthy"; "replace sleep(2) with a poll on <condition>"; "split into one test per behavior"]
+```
+
+After the findings, add an **Observed Conventions** section: the framework(s) and runner in use, the dominant file/naming layout, the prevailing assertion and fixture style, and any house patterns you can infer. Keep it factual — the dispatching skill uses this to offer the repo a written testing-conventions note. If a finding flags a test that *deviates* from an otherwise-consistent convention, say so.
+
+## Machine-Readable Summary
+
+End your response with a fenced block tagged `json audit-summary` — the dispatching skill parses it to group fixes and drive the implementer dispatch. It must be the LAST fenced block in your response.
+
+```json audit-summary
+{
+  "issues_found": 2,
+  "severity": { "critical": 1, "high": 1, "medium": 0, "low": 0 },
+  "issues": [
+    { "id": 1, "severity": "critical", "category": "False-pass risk", "file": "tests/test_auth.py:14", "problem": "Test calls login() but has no assertion — passes even if login throws nothing useful", "fix": "Assert the returned session token is non-empty and the user id matches" },
+    { "id": 2, "severity": "high", "category": "Flakiness & determinism", "file": "tests/test_jobs.py:40", "problem": "sleep(2) waits for a background job; fails under load", "fix": "Poll job.status with a timeout instead of a fixed sleep" }
+  ]
+}
+```
+
+If zero findings: `{"issues_found": 0, "severity": {"critical": 0, "high": 0, "medium": 0, "low": 0}, "issues": []}` and write the literal line `No findings.` as the human-readable body above it.
+
+## Quality Bar
+
+Report only real issues you can point to in the test code. A clean suite is a valid outcome — do NOT invent findings to populate the list. If you have to stretch to justify a finding, drop it.
+
+## Hard Rules
+
+- **Test and source files are read-only.** Use `Read`, `Grep`, `Glob`, and read-only `Bash` only. Do not modify, rename, or delete any file.
+- **Cite `file:line` for every finding.** "Some tests are flaky" is not acceptable — name the file and line.
+- **Audit test quality, not production code.** If you spot a production bug, mention it once in passing, but it is out of scope — your findings are about the tests.
+- **Every finding needs a concrete fix.** The skill hands these to implementers verbatim, so a vague fix wastes a dispatch.

--- a/agents/test-auditor.md
+++ b/agents/test-auditor.md
@@ -13,6 +13,8 @@ You are a test-suite auditor. Your job is to read test code and report concrete,
 
 You audit the tests, not the production code. A weak test is a finding even when the code under test is correct — the point is whether the test would actually catch a regression. Bash is available for read-only inspection (`git diff`, listing files, and — when it is cheap and safe — running the targeted tests to observe failures, ordering effects, or flakiness). Never modify files.
 
+**The falsification gate is your spine.** A test has value only if some plausible bug would make an assertion fail. So every finding must name a *concrete* bug the test fails to catch — the regression, the observation point, and the assertion that should (but wouldn't) fail. "Weak assertion" without a named bug it lets through is not a finding; "can't name any bug this test would catch" *is* the finding (a false-pass test). This gate also disciplines you: if you can't name the escaping bug, drop the finding.
+
 ## Audit Categories
 
 **1. False-pass risk** — tests that pass without proving anything
@@ -67,10 +69,19 @@ For each finding, emit a block of this shape:
 Finding N:
 - Category: [False-pass risk | Flakiness & determinism | Assertion quality & coverage | Isolation & fixtures | Maintainability & clarity]
 - Severity: [Critical | High | Medium | Low]
+- Disposition: [strengthen | remove | add-missing | move-level | monitor]
 - File(s): [exact file paths with line numbers]
-- Problem: [what is wrong with the test, concretely — and what regression it would fail to catch]
+- Problem: [what is wrong, concretely, AND the falsification gate: name the plausible bug this test fails to catch and the assertion that should fail]
 - Recommended fix: [the specific edit — e.g. "assert the returned status is 200, not just truthy"; "replace sleep(2) with a poll on <condition>"; "split into one test per behavior"]
 ```
+
+**Disposition** routes the fix; pick the one that matches the remedy:
+
+- **strengthen** — the test stays but its assertion/oracle/fixture must change to catch the named bug
+- **remove** — the test is net-negative (tautological, compile-time-only, asserts a mock's own return) and should be deleted; it gives false coverage credit
+- **add-missing** — the gap is an absent test (untested error path, boundary, or behavior), not a flawed one; write a new test
+- **move-level** — the behavior is tested at the wrong layer (e.g. an E2E that should be a unit test, or a unit test mocking the very integration that matters)
+- **monitor** — this isn't a test fix at all; the risk is better served by a runtime monitor/canary/alert (note it, don't expect an implementer to "fix" a test)
 
 After the findings, add an **Observed Conventions** section: the framework(s) and runner in use, the dominant file/naming layout, the prevailing assertion and fixture style, and any house patterns you can infer. Keep it factual — the dispatching skill uses this to offer the repo a written testing-conventions note. If a finding flags a test that *deviates* from an otherwise-consistent convention, say so.
 
@@ -83,17 +94,29 @@ End your response with a fenced block tagged `json audit-summary` — the dispat
   "issues_found": 2,
   "severity": { "critical": 1, "high": 1, "medium": 0, "low": 0 },
   "issues": [
-    { "id": 1, "severity": "critical", "category": "False-pass risk", "file": "tests/test_auth.py:14", "problem": "Test calls login() but has no assertion — passes even if login throws nothing useful", "fix": "Assert the returned session token is non-empty and the user id matches" },
-    { "id": 2, "severity": "high", "category": "Flakiness & determinism", "file": "tests/test_jobs.py:40", "problem": "sleep(2) waits for a background job; fails under load", "fix": "Poll job.status with a timeout instead of a fixed sleep" }
+    { "id": 1, "severity": "critical", "category": "False-pass risk", "disposition": "strengthen", "file": "tests/test_auth.py:14", "problem": "Test calls login() but has no assertion — a regression returning a null/empty session would still pass", "fix": "Assert the returned session token is non-empty and the user id matches" },
+    { "id": 2, "severity": "high", "category": "Flakiness & determinism", "disposition": "strengthen", "file": "tests/test_jobs.py:40", "problem": "sleep(2) waits for a background job; under load the job isn't done at 2s and the test flakes red on correct code", "fix": "Poll job.status with a timeout instead of a fixed sleep" }
   ]
 }
 ```
 
 If zero findings: `{"issues_found": 0, "severity": {"critical": 0, "high": 0, "medium": 0, "low": 0}, "issues": []}` and write the literal line `No findings.` as the human-readable body above it.
 
+## Suite Health (synthesis mode only)
+
+When the dispatch prompt asks for a **suite-health synthesis** (full-suite audits, not a diff gate), you also receive the test-file inventory by layer and the aggregated per-file findings. Assess the suite as a *risk-control system*, not a pile of files, and report problems no single file reveals:
+
+- **Pyramid balance** — ice-cream-cone (many slow E2E, few unit/contract tests); behaviors tested at the wrong layer
+- **Duplicated coverage** — the same behavior asserted at several layers; keep the narrowest reliable test unless a broader one protects unique integration risk
+- **Happy-path skew** — error paths, boundaries, abuse, and recovery underrepresented across the suite
+- **Lost protection** — skipped/quarantined/`xfail`/silently-skipping tests with no owner, reason, or expiry (a green suite that validates nothing on CI is the worst case)
+- **Risk-coverage gaps** — critical workflows with no mapped test
+
+Then grade the suite **A–F** from these dimensions (reliability, speed, signal, diagnostics, maintainability, risk coverage, monitoring), with hard caps: unowned quarantines or routine reruns cap at **C**; ignored red builds, no ownership, or repeated missed critical risks cap at **D**; tests disabled to ship without risk acceptance is **F**. State the one-line evidence behind the grade — a grade detached from cited findings is noise. Static smells are hypotheses: say so when you couldn't confirm flakiness/runtime from execution history.
+
 ## Quality Bar
 
-Report only real issues you can point to in the test code. A clean suite is a valid outcome — do NOT invent findings to populate the list. If you have to stretch to justify a finding, drop it.
+Report only real issues you can point to in the test code, each clearing the falsification gate (a named escaping bug). A clean suite is a valid outcome — do NOT invent findings to populate the list. If you have to stretch to justify a finding, drop it.
 
 ## Hard Rules
 

--- a/skills/test-audit/SKILL.md
+++ b/skills/test-audit/SKILL.md
@@ -20,14 +20,16 @@ The audit itself is read-only. Fixes happen only after you approve them, via sep
 
 ## Phase 1 — Resolve Scope
 
-Parse the user's arguments into structured tokens before calling the helper — do NOT interpolate raw user input into the shell, which is a command-injection risk for inputs containing `;`, `&&`, `|`, or backticks. Wrap each parsed token in single quotes; escape any literal single quote as `'\''`.
+Parse the user's arguments into structured tokens before calling the helper — do NOT interpolate raw user input into the shell, which is a command-injection risk for inputs containing `;`, `&&`, `|`, or backticks. Wrap each parsed token in its own single quotes (escape any literal single quote as `'\''`) and pass them as **separate** arguments — never as one quoted blob, which the helper would see as a single bogus path.
 
-Run `./skills/test-audit/scope-detect.sh '<tokens…>'`. Parse stdout (`KEY=value` per line): `SCOPE_MODE` (`full`|`diff`), `SCOPE_PATH`, and in diff mode `BASE_REF`. A non-zero exit means bad arguments — surface stderr and stop.
+Examples: `/test-audit` → `./skills/test-audit/scope-detect.sh`; `/test-audit src --diff` → `./skills/test-audit/scope-detect.sh 'src' '--diff'`; `/test-audit --base=develop --diff` → `./skills/test-audit/scope-detect.sh '--base=develop' '--diff'`.
+
+Parse stdout (`KEY=value` per line): `SCOPE_MODE` (`full`|`diff`), `SCOPE_PATH`, and in diff mode `BASE_REF`. A non-zero exit means bad arguments or a nonexistent path — surface stderr and stop.
 
 Discover the test files:
 
 - **full:** find test files under `SCOPE_PATH` using the repo's conventions (e.g. `*_test.*`, `test_*.*`, `*.test.*`, `*.spec.*`, files under `tests/`/`__tests__/`/`spec/`). Confirm the framework from config (`package.json`, `pyproject.toml`/`pytest.ini`, `go.mod`, `*.csproj`, etc.).
-- **diff:** `git diff --name-only "$BASE_REF"... -- <test-path-globs>` to get changed test files only. If none changed, report that and stop.
+- **diff:** `git diff --name-only "$BASE_REF"... -- <test-path-globs>` to get changed test files only; when a path was given, scope it to `SCOPE_PATH` by using that path in the `git diff` pathspec (otherwise `/test-audit src --diff` silently ignores `src`). If none changed, report that and stop.
 
 If the test set is empty, say so and stop — there is nothing to audit.
 

--- a/skills/test-audit/SKILL.md
+++ b/skills/test-audit/SKILL.md
@@ -38,38 +38,50 @@ Group the test files by top-level test directory (or logical module). Dispatch o
 - The exact list of test files (or the directory) that subagent owns
 - `SCOPE_MODE` and, in diff mode, the `BASE_REF` so it can read the diff
 
-The agent definition supplies the five categories, severity rubric, output format, and the `json audit-summary` block — do not restate them. For a small suite (one directory, few files), a single subagent is fine.
+The agent definition supplies the five categories, severity rubric, disposition values, falsification gate, output format, and the `json audit-summary` block — do not restate them. For a small suite (one directory, few files), a single subagent is fine.
 
 ## Phase 3 — Aggregate & Surface
 
 Collect each subagent's findings and parse its `json audit-summary` block. Merge into one list, deduplicate, and sort by severity (Critical → Low). Also collect the **Observed Conventions** sections.
+
+**Suite-health synthesis (full mode only).** After the per-file audits return, dispatch one more **`claude-caliper:test-auditor`** subagent in *suite-health synthesis* mode. Give it the test-file inventory grouped by layer (unit / component / integration / e2e, inferred from paths), the aggregated findings, and any CI config you can see. It returns the suite-level problems (pyramid balance, cross-layer duplication, happy-path skew, lost protection, risk-coverage gaps) and an A–F grade with one-line evidence. Skip this in diff mode — a changed-tests gate isn't a suite assessment.
 
 Present a report to the user:
 
 ```text
 # Test Audit — <scope> (<full | diff vs BASE_REF>)
 Audited: <N> test files | Findings: <C> Critical, <H> High, <M> Medium, <L> Low
+Suite health: <grade A–F> — <one-line evidence>   (full mode only)
 
 ## Findings by Severity
-| # | Severity | Category | File:line | Problem | Recommended fix |
+| # | Severity | Disposition | Category | File:line | Problem (incl. the bug it misses) | Recommended fix |
+
+## Suite Health   (full mode only)
+<pyramid / duplication / happy-path / lost-protection / risk-coverage problems>
 ```
 
 If there are zero findings, say so plainly and skip to Phase 5 (the conventions offer still applies).
 
 ## Phase 4 — Offer to Fix
 
-Test fixes are directly implementable — they don't need their own design cycle. Use `AskUserQuestion` (header `Fix tests`) to let the user choose which findings to fix:
+Most test fixes are directly implementable — they don't need their own design cycle. Use `AskUserQuestion` (header `Fix tests`) to let the user choose which findings to fix:
 
 - **All findings**
 - **Critical + High only**
 - **Let me pick** — then list findings by id and take their selection
 - **None** — skip to Phase 5
 
-For the approved findings, group them **by file** (so no two implementers touch the same file), then dispatch one **`claude-caliper:task-implementer`** subagent per file group, in parallel. Each task brief contains, per finding: the `file:line`, the problem, and the agent's recommended fix — plus this verification instruction:
+Route each approved finding by its **disposition** — they are not all "edit a test":
 
-> Apply each fix. Then run the affected test(s) and confirm they still pass and now actually assert the intended behavior (a fix that makes a test meaningfully *able to fail* is correct even if it now reveals a real bug — in that case, report the bug rather than weakening the test back). Do not change production code to make a test pass; if a corrected test exposes a production defect, report it.
+- **monitor** findings are *not* dispatched to an implementer (the remedy is a runtime monitor/alert, not a test edit). Collect them into a "Monitoring gaps" note shown to the user instead.
+- **move-level** findings carry an instruction to rewrite the behavior at the correct layer (and delete the misplaced test), not just tweak it.
+- **strengthen / add-missing / remove** are ordinary test edits (remove = delete the net-negative test).
 
-These implementers work on the current branch — they are not creating a new feature, so no per-task worktree is needed. After they return, show a short summary of what changed and the test results.
+For the implementable findings, group them **by file** (so no two implementers touch the same file), then dispatch one **`claude-caliper:task-implementer`** subagent per file group, in parallel. Each task brief contains, per finding: the `file:line`, the disposition, the problem (including the bug it currently misses), and the recommended fix — plus this verification instruction:
+
+> Apply each fix per its disposition. Then run the affected test(s) and confirm they still pass and now actually assert the intended behavior — specifically, that the test would now fail for the bug named in the finding (a fix that makes a test meaningfully *able to fail* is correct even if it reveals a real bug — in that case, report the bug rather than weakening the test back). Do not change production code to make a test pass; if a corrected test exposes a production defect, report it.
+
+These implementers work on the current branch — they are not creating a new feature, so no per-task worktree is needed. After they return, show a short summary of what changed, the test results, and any deferred monitoring gaps.
 
 ## Phase 5 — Offer Testing Conventions
 

--- a/skills/test-audit/SKILL.md
+++ b/skills/test-audit/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: test-audit
+description: Use when asked to audit unit tests, check test quality/health, find flaky or weak tests, or review the test suite for smells — repo-wide or on changed tests
+---
+
+# Test Audit
+
+Audits a test suite for quality problems — false-pass risk, flakiness, weak assertions, poor isolation, and maintainability smells — surfaces findings, then offers to fix them and to record the repo's testing conventions.
+
+**Not for:** auditing production code (use `codebase-review`), or reviewing a branch's whole implementation (use `implementation-review`). This skill judges whether the *tests* would catch regressions.
+
+The audit itself is read-only. Fixes happen only after you approve them, via separate implementers.
+
+## Invocation
+
+- `/test-audit` — audit all tests in the repo
+- `/test-audit path/to/dir` — limit to a directory
+- `/test-audit --diff` — audit only tests changed vs the default branch
+- `/test-audit --diff --base=<ref>` — diff against a specific ref
+
+## Phase 1 — Resolve Scope
+
+Parse the user's arguments into structured tokens before calling the helper — do NOT interpolate raw user input into the shell, which is a command-injection risk for inputs containing `;`, `&&`, `|`, or backticks. Wrap each parsed token in single quotes; escape any literal single quote as `'\''`.
+
+Run `./skills/test-audit/scope-detect.sh '<tokens…>'`. Parse stdout (`KEY=value` per line): `SCOPE_MODE` (`full`|`diff`), `SCOPE_PATH`, and in diff mode `BASE_REF`. A non-zero exit means bad arguments — surface stderr and stop.
+
+Discover the test files:
+
+- **full:** find test files under `SCOPE_PATH` using the repo's conventions (e.g. `*_test.*`, `test_*.*`, `*.test.*`, `*.spec.*`, files under `tests/`/`__tests__/`/`spec/`). Confirm the framework from config (`package.json`, `pyproject.toml`/`pytest.ini`, `go.mod`, `*.csproj`, etc.).
+- **diff:** `git diff --name-only "$BASE_REF"... -- <test-path-globs>` to get changed test files only. If none changed, report that and stop.
+
+If the test set is empty, say so and stop — there is nothing to audit.
+
+## Phase 2 — Dispatch the Auditor
+
+Group the test files by top-level test directory (or logical module). Dispatch one **`claude-caliper:test-auditor`** subagent per group, all in parallel in a single message. Each dispatch prompt provides:
+
+- The exact list of test files (or the directory) that subagent owns
+- `SCOPE_MODE` and, in diff mode, the `BASE_REF` so it can read the diff
+
+The agent definition supplies the five categories, severity rubric, output format, and the `json audit-summary` block — do not restate them. For a small suite (one directory, few files), a single subagent is fine.
+
+## Phase 3 — Aggregate & Surface
+
+Collect each subagent's findings and parse its `json audit-summary` block. Merge into one list, deduplicate, and sort by severity (Critical → Low). Also collect the **Observed Conventions** sections.
+
+Present a report to the user:
+
+```text
+# Test Audit — <scope> (<full | diff vs BASE_REF>)
+Audited: <N> test files | Findings: <C> Critical, <H> High, <M> Medium, <L> Low
+
+## Findings by Severity
+| # | Severity | Category | File:line | Problem | Recommended fix |
+```
+
+If there are zero findings, say so plainly and skip to Phase 5 (the conventions offer still applies).
+
+## Phase 4 — Offer to Fix
+
+Test fixes are directly implementable — they don't need their own design cycle. Use `AskUserQuestion` (header `Fix tests`) to let the user choose which findings to fix:
+
+- **All findings**
+- **Critical + High only**
+- **Let me pick** — then list findings by id and take their selection
+- **None** — skip to Phase 5
+
+For the approved findings, group them **by file** (so no two implementers touch the same file), then dispatch one **`claude-caliper:task-implementer`** subagent per file group, in parallel. Each task brief contains, per finding: the `file:line`, the problem, and the agent's recommended fix — plus this verification instruction:
+
+> Apply each fix. Then run the affected test(s) and confirm they still pass and now actually assert the intended behavior (a fix that makes a test meaningfully *able to fail* is correct even if it now reveals a real bug — in that case, report the bug rather than weakening the test back). Do not change production code to make a test pass; if a corrected test exposes a production defect, report it.
+
+These implementers work on the current branch — they are not creating a new feature, so no per-task worktree is needed. After they return, show a short summary of what changed and the test results.
+
+## Phase 5 — Offer Testing Conventions
+
+From the merged **Observed Conventions**, check whether the repo's `CLAUDE.md` (or `AGENTS.md`) already documents testing conventions. If it has no testing section, or the audit revealed a convention worth codifying (a dominant framework/layout/assertion style, or a recurring smell worth a "don't do X" rule), offer to add one.
+
+Draft a concise **Testing Conventions** section — framework & runner, file/naming layout, assertion and fixture style, and any "avoid <smell>" rules the findings justify. Show the exact proposed text and use `AskUserQuestion` (header `Conventions`) to confirm before writing. On yes, append it to the repo's `CLAUDE.md` (create the file only if the user agrees). On no, leave `CLAUDE.md` untouched.
+
+Keep the section short and specific to what the audit actually observed — do not pad it with generic testing advice the model already knows.

--- a/skills/test-audit/scope-detect.sh
+++ b/skills/test-audit/scope-detect.sh
@@ -53,11 +53,20 @@ done
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 
-# Resolve SCOPE_PATH (path arg wins; fall back to git toplevel, then cwd)
-if [[ -z "$scope_path" ]]; then
+# Resolve SCOPE_PATH. A user-supplied path must exist — a typo should be a loud
+# error, not a silent no-op — and may be a file or a directory. The
+# git-toplevel/cwd fallback always exists.
+if [[ -n "$scope_path" ]]; then
+  if [[ -d "$scope_path" ]]; then
+    scope_path="$(cd "$scope_path" && pwd -P)"
+  elif [[ -f "$scope_path" ]]; then
+    scope_path="$(cd "$(dirname "$scope_path")" && pwd -P)/$(basename "$scope_path")"
+  else
+    echo "ERROR: path '$scope_path' does not exist." >&2
+    exit 1
+  fi
+else
   scope_path="${repo_root:-.}"
-fi
-if [[ -e "$scope_path" ]]; then
   scope_path="$(cd "$scope_path" && pwd -P)"
 fi
 
@@ -77,8 +86,11 @@ if [[ "$mode" == "diff" ]]; then
       :
     elif base_ref="$(git merge-base "$default_branch" HEAD 2>/dev/null)"; then
       :
-    else
+    elif git rev-parse --verify -q HEAD~1 >/dev/null; then
       base_ref="HEAD~1"
+    else
+      # Single-commit repo: diff against the empty tree (all files read as added).
+      base_ref="$(git hash-object -t tree /dev/null)"
     fi
   fi
   echo "BASE_REF=$base_ref"

--- a/skills/test-audit/scope-detect.sh
+++ b/skills/test-audit/scope-detect.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# scope-detect.sh — Resolve audit scope for the test-audit skill.
+#
+# Usage: scope-detect.sh [path] [--diff] [--base=<ref>]
+#   path        Optional directory to limit the audit to (full mode only).
+#   --diff      Audit only test files changed vs the base ref.
+#   --base=REF  Base ref for --diff (default: merge-base with the default branch).
+#
+# The skill passes each user-supplied token single-quoted, so this script never
+# interpolates raw input into a shell expansion (no command-injection surface).
+#
+# Stdout (one key=value line per resolved variable):
+#   SCOPE_MODE=full | diff
+#   SCOPE_PATH=<absolute path>          (repo root, or the path arg if given)
+#   BASE_REF=<ref>                      (diff mode only)
+#
+# Exit codes:
+#   0 — success
+#   1 — invalid arguments or not a git repo (diff mode)
+
+mode="full"
+scope_path=""
+base_ref=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --diff)
+      mode="diff"
+      shift
+      ;;
+    --base=*)
+      base_ref="${1#--base=}"
+      shift
+      ;;
+    --base)
+      echo "ERROR: --base requires a value, e.g. --base=main." >&2
+      exit 1
+      ;;
+    --*)
+      # Unknown flag — skip silently (forward compatibility)
+      shift
+      ;;
+    *)
+      if [[ -z "$scope_path" ]]; then
+        scope_path="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+
+# Resolve SCOPE_PATH (path arg wins; fall back to git toplevel, then cwd)
+if [[ -z "$scope_path" ]]; then
+  scope_path="${repo_root:-.}"
+fi
+if [[ -e "$scope_path" ]]; then
+  scope_path="$(cd "$scope_path" && pwd -P)"
+fi
+
+echo "SCOPE_MODE=$mode"
+echo "SCOPE_PATH=$scope_path"
+
+if [[ "$mode" == "diff" ]]; then
+  if [[ -z "$repo_root" ]]; then
+    echo "ERROR: --diff requires a git repository." >&2
+    exit 1
+  fi
+  if [[ -z "$base_ref" ]]; then
+    # Default base: the default branch's merge-base, falling back to HEAD~1.
+    default_branch="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || true)"
+    default_branch="${default_branch:-main}"
+    if base_ref="$(git merge-base "origin/$default_branch" HEAD 2>/dev/null)"; then
+      :
+    elif base_ref="$(git merge-base "$default_branch" HEAD 2>/dev/null)"; then
+      :
+    else
+      base_ref="HEAD~1"
+    fi
+  fi
+  echo "BASE_REF=$base_ref"
+fi


### PR DESCRIPTION
## Summary
- New **`test-auditor`** agent (read-only) + **`test-audit`** skill for the tooling plugin: audits a unit-test suite for false-pass risk, flakiness/determinism, assertion quality & coverage, isolation/fixtures, and maintainability smells — grounded in the test-smell literature (testsmells.org, "Test smells 20 years later") and patterns borrowed from `workersio/skills`.
- Findings are severity-tagged (Critical/High/Med/Low) with a **falsification gate** (each must name a concrete bug the test fails to catch) and a **disposition** (`strengthen|remove|add-missing|move-level|monitor`); a machine-readable `json audit-summary` lets the skill route fixes to `task-implementer` subagents.
- Skill resolves scope (full suite or `--diff` changed tests via `scope-detect.sh`), fans out auditors in parallel, surfaces findings, and — in **full mode** — adds a suite-health synthesis pass with an A–F grade (pyramid balance, cross-layer duplication, happy-path skew, lost protection). Also offers to record observed testing conventions in `CLAUDE.md`.
- Registered in the `claude-caliper` and `claude-caliper-tooling` packages (version bumps); README updated.

## Test plan
- Full bash suite green (27/27 `caliper-test_*.sh`).
- `scope-detect.sh` smoke-tested across full / path / `--diff` / `--base` / bad-arg cases; `marketplace.json` validates.
- End-to-end dry run: dispatched the auditor across a real ~20k-LOC dual-language suite (`personal/investing`), producing 62 actionable findings — exercising the categories, severity model, and JSON summary.

Note: as a new skill, this wants a `/skill-eval` run before merge per repo convention.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `test-audit` skill to audit test quality across multiple dimensions: false-pass risk, flakiness, assertion quality, isolation, and maintainability.
  * Available via `/test-audit` command supporting full-suite analysis and `--diff` mode for change-focused audits, with severity-level findings and recommended fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->