### PR TITLE
feat(skills): add queue and usage-guard usage-window scheduling skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.49.1",
+      "version": "1.50.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -28,7 +28,9 @@
         "./skills/pr-review",
         "./skills/pr-merge",
         "./skills/skill-eval",
-        "./skills/caliper-settings"
+        "./skills/caliper-settings",
+        "./skills/queue",
+        "./skills/usage-guard"
       ]
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -58,8 +58,8 @@
     },
     {
       "name": "claude-caliper-tooling",
-      "description": "Standalone tools: codebase audit, test audit, and skill evaluation",
-      "version": "1.48.0",
+      "description": "Standalone tools: codebase audit, test audit, skill evaluation, and usage-window scheduling (queue / usage-guard)",
+      "version": "1.49.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -69,7 +69,9 @@
       "skills": [
         "./skills/codebase-review",
         "./skills/test-audit",
-        "./skills/skill-eval"
+        "./skills/skill-eval",
+        "./skills/queue",
+        "./skills/usage-guard"
       ]
     }
   ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,10 @@ All shell scripts (`bin/*`, `tests/**/*.sh`) must have a `#!/usr/bin/env bash` s
 
 In `hooks/hooks.json`, `command`-type hooks always require a `command` string — even in exec form, where `command` is the *executable* and `args` is its argument vector (e.g. `"command": "bash", "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/x.sh"]`). Putting the script path in `args` with no `command` fails schema validation (`command: expected string, received undefined`) and silently disables every hook.
 
+### Platform-specific & externally-wired skills
+
+`queue` and `usage-guard` use BSD `date` (`date -r <epoch>`, `date -j -f`) and are **macOS-only** — `date -r` reads a file mtime on GNU/Linux. Their tests guard with `date -r 0 >/dev/null 2>&1` and print `SKIP` rather than fail, so they are intentionally **not** wired into the Linux CI job; run them on macOS. They also depend on a statusline tap (`skills/queue/scripts/statusline-wrapper.sh`) the user must wire into `statusLine` themselves — a plugin can't auto-edit user settings. When a skill needs that kind of out-of-band setup, document it in the skill's `README.md` and gate the dependent path behind a clear error, as `queue` does.
+
 ## Development Workflow
 
 This repo uses its own skills. The typical flow: design -> worktree -> draft-plan -> orchestrate -> pr-create -> pr-review -> pr-merge.

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Install only what you need:
 
 | Package | What you get | Install command |
 |---------|-------------|-----------------|
-| **claude-caliper** | All 14 skills | `/plugin install claude-caliper@claude-caliper` |
-| **claude-caliper-workflow** | Design-to-merge pipeline (9 skills) | `/plugin install claude-caliper-workflow@claude-caliper` |
+| **claude-caliper** | All 15 skills | `/plugin install claude-caliper@claude-caliper` |
+| **claude-caliper-workflow** | Design-to-merge pipeline (10 skills) | `/plugin install claude-caliper-workflow@claude-caliper` |
 | **claude-caliper-tooling** | Codebase review + test audit + skill eval + queue + usage-guard (5 skills) | `/plugin install claude-caliper-tooling@claude-caliper` |
 
 ### Updating

--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ Install only what you need:
 
 | Package | What you get | Install command |
 |---------|-------------|-----------------|
-| **claude-caliper** | All 12 skills | `/plugin install claude-caliper@claude-caliper` |
+| **claude-caliper** | All 14 skills | `/plugin install claude-caliper@claude-caliper` |
 | **claude-caliper-workflow** | Design-to-merge pipeline (9 skills) | `/plugin install claude-caliper-workflow@claude-caliper` |
-| **claude-caliper-tooling** | Codebase review + test audit + skill eval (3 skills) | `/plugin install claude-caliper-tooling@claude-caliper` |
+| **claude-caliper-tooling** | Codebase review + test audit + skill eval + queue + usage-guard (5 skills) | `/plugin install claude-caliper-tooling@claude-caliper` |
 
 ### Updating
 
@@ -167,6 +167,15 @@ These skills chain automatically. You trigger the first one by describing what t
 | [codebase-review](skills/codebase-review/) | `/codebase-review [path]` | Whole-repo audit with parallel subagents per directory, cross-scope reconciliation, findings triaged by fix complexity |
 | [test-audit](skills/test-audit/) | `/test-audit [path] [--diff]` | Audits the test suite for false-pass risk, flakiness, weak assertions, and isolation smells; surfaces findings, dispatches implementers to fix approved ones, offers to record testing conventions |
 | [skill-eval](skills/skill-eval/) | `/skill-eval` | Assertion-based grading, blind A/B comparison, adversarial scenarios, variance analysis |
+
+### Usage-window scheduling
+
+Defer or pace work around Claude's 5-hour usage window. **macOS-only**, and reset-mode needs a one-time statusline setup — see [queue/README](skills/queue/README.md).
+
+| Skill | Trigger | What it does |
+|-------|---------|-------------|
+| [queue](skills/queue/) | `/queue [<when>] <commands>` | Schedule commands to fire later in the same session via a one-shot cron — by default ~90s after the 5h window resets (fresh quota), or at a time/duration you name |
+| [usage-guard](skills/usage-guard/) | `/usage-guard [--queue] [--at <pct>] <task>` | Work a task continuously until 5h usage hits a threshold (default 99%), then stop and report — or with `--queue`, chain the remainder into the next block |
 
 ---
 

--- a/skills/queue/README.md
+++ b/skills/queue/README.md
@@ -1,0 +1,84 @@
+# queue
+
+Schedule commands to fire later **in the same Claude Code session**, via a
+one-shot `CronCreate` job. By default it fires ~90 seconds after the current
+5-hour usage window resets (so deferred work lands on fresh quota); you can also
+give an explicit time/duration (`/queue in 2h …`, `/queue 3pm …`,
+`/queue 10am tomorrow …`).
+
+Pairs with the `usage-guard` skill, which reads the same usage state.
+
+## Requirement: the statusline tap
+
+The 5-hour window reset time (`rate_limits.five_hour.resets_at`) and percent used
+are exposed by Claude Code **only** in the JSON piped to your `statusLine`
+command's stdin — not in any file or CLI. So reset-mode depends on a thin
+statusline wrapper that captures those fields to a state file on the way through
+to your real statusline renderer.
+
+`scripts/statusline-wrapper.sh` does exactly that: it reads stdin once, writes
+`{resets_at, used_percentage, captured_at}` to the state file, then forwards the
+same stdin to your renderer (default `bunx -y ccstatusline@latest`) unchanged.
+
+### Wiring it in
+
+Point your `statusLine` command at the wrapper. Because plugin cache paths change
+on update, the robust setup is to copy the wrapper to a stable location and point
+`settings.json` there:
+
+```bash
+mkdir -p ~/.claude/queue
+cp "<plugin>/skills/queue/scripts/statusline-wrapper.sh" ~/.claude/queue/
+chmod +x ~/.claude/queue/statusline-wrapper.sh
+```
+
+```jsonc
+// ~/.claude/settings.json
+"statusLine": {
+  "type": "command",
+  "command": "bash ~/.claude/queue/statusline-wrapper.sh",
+  "padding": 0,
+  "refreshInterval": 10
+}
+```
+
+Already running a custom statusline? Set `QUEUE_STATUSLINE` to it (the wrapper
+forwards stdin to that command instead of `ccstatusline`):
+
+```bash
+QUEUE_STATUSLINE="my-statusline --flags" bash ~/.claude/queue/statusline-wrapper.sh
+```
+
+Give the terminal ~10–15 s to render once, then confirm:
+
+```bash
+cat ~/.claude/queue/state.json   # {"resets_at":…, "used_percentage":…, "captured_at":…}
+```
+
+`resets_at`/`used_percentage` only appear for Pro/Max subscribers, after the
+first API response of a session.
+
+## Configuration (env)
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `QUEUE_STATE_FILE` | `~/.claude/queue/state.json` | Where state is read/written |
+| `QUEUE_STATUSLINE` | `bunx -y ccstatusline@latest` | The real statusline to forward to |
+
+## Notes & limits
+
+- **macOS/BSD only** — the scripts use `date -r <epoch>` / `date -j -f`.
+- **Session-only by default** — `CronCreate` jobs live in memory and die when
+  Claude exits (pass `durable: true` to persist). They fire only while the REPL
+  is idle.
+- The fire time dodges the `:00`/`:30` minute marks in reset mode, because
+  `CronCreate` fires one-shots landing there up to 90 s early.
+- Cron is **minute-granular**; sub-minute durations bump to the next whole minute.
+
+## Files
+
+- `SKILL.md` — model-facing instructions.
+- `scripts/compute-fire.sh` — resolves reset time (or an explicit epoch) into a one-shot cron expression.
+- `scripts/statusline-wrapper.sh` — the statusline tap.
+
+Tests: `tests/queue/caliper-test_compute_fire.sh`.

--- a/skills/queue/README.md
+++ b/skills/queue/README.md
@@ -81,4 +81,6 @@ first API response of a session.
 - `scripts/compute-fire.sh` — resolves reset time (or an explicit epoch) into a one-shot cron expression.
 - `scripts/statusline-wrapper.sh` — the statusline tap.
 
-Tests: `tests/queue/caliper-test_compute_fire.sh`.
+Tests: `tests/queue/caliper-test_compute_fire.sh` (compute-fire unit tests) and
+`tests/queue/caliper-test_statusline_seam.sh` (end-to-end: wrapper → state file →
+both consumers).

--- a/skills/queue/SKILL.md
+++ b/skills/queue/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: queue
+description: Queue commands to fire automatically at a future time — by default right after the current Claude 5-hour usage window resets (so the work runs on the fresh quota in this same session), or at a time the user names. Use when the user runs `/queue <commands>`, `/queue <when> <commands>`, says "queue this for the next window", "run this after my limit resets", "defer this to the next 5-hour block", "run this in 2 hours", "do this at 3pm", or "10am tomorrow run X".
+---
+
+# /queue — schedule commands to fire in this session at a future time
+
+The user wants a set of commands to run later, **in this same session**, via a
+one-shot `CronCreate` job. The default trigger is the moment their current
+5-hour usage window resets (so the work lands on fresh quota); they can instead
+name an explicit time or duration.
+
+`/queue [<when>] <commands>` — `<when>` is optional; everything else is the
+QUEUED PAYLOAD.
+
+> **Requires the statusline tap** for reset-mode (the default): the wrapper
+> `./skills/queue/scripts/statusline-wrapper.sh` must be wired in as your
+> `statusLine` command so it can capture the 5-hour reset time to the state
+> file — see this skill's `README.md`. Without it, reset-mode has no data, but
+> explicit `<when>` targets still work. (macOS/BSD `date` only.)
+
+## Resolve the fire time
+
+Inspect the start of the invocation for an optional `<when>`. **Times are local —
+cron fires in the machine's local timezone, so no conversion is needed; let
+`date` resolve it (if the user names a different zone, convert to local).**
+
+- **No time given** → 5h-window-reset mode. Run the helper with no args:
+  ```
+  ./skills/queue/scripts/compute-fire.sh
+  ```
+  (Invoke it directly — it's executable. Do NOT prefix with `bash`.)
+
+- **A duration** ("in 2h", "in 90m", "2h30m") or **clock time** ("3pm", "15:00",
+  "3:30pm") or **natural language** ("10am tomorrow", "tomorrow at 9",
+  "friday 5pm") → resolve it yourself to an absolute Unix epoch, then:
+  1. Get current epoch + wall clock from the machine: `date '+%s | %Y-%m-%d %H:%M:%S %Z'`.
+     **Let `date` own the timezone** — compute the epoch for the intended
+     wall-clock in the machine's local zone (don't hand-apply a Central offset).
+  2. Compute the target epoch. A bare clock time means the next occurrence —
+     today if still future, else tomorrow.
+  3. **Always confirm before scheduling:** run `date -r <epoch>` and check the
+     printed wall-clock matches what the user meant. Don't skip this.
+  4. Run: `./skills/queue/scripts/compute-fire.sh --epoch <epoch>`
+
+  Cron is **minute-granular** — sub-minute durations ("in 30s") can't be honored
+  exactly; the helper bumps them to the next whole minute. The helper floors to
+  the minute and honors explicit times; if the named time lands on `:00`/`:30`,
+  mention it may fire up to ~90s early (CronCreate one-shot jitter) and offer to
+  nudge a minute.
+
+The helper prints `CRON=`, `FIRE_HUMAN=`, `MINUTES_AWAY=`, and either
+`RESET_HUMAN=` (reset mode) or `TARGET_HUMAN=` (explicit). In reset mode it also
+prints `STALE=yes|no`. On non-zero exit, relay the stderr message and do not
+schedule — exit 1/2 = no reset time captured (keep terminal focused ~10-15s and
+retry); 3 = target in the past; 4 = bad `--epoch`. If a `WARNING:` is printed
+(stale state, or a DST-gap fire time), surface it: for `STALE=yes`, refresh the
+statusline (focus terminal ~10s, re-run) before trusting the reset time.
+
+## Schedule the one-shot
+
+With the helper's output, call `CronCreate`:
+- `cron`: the `CRON` value, verbatim.
+- `recurring`: `false`
+- `durable`: `false` — session-only, matches keep-this-session-open. Only `true`
+  if the user explicitly wants it to survive a restart.
+- `prompt`: re-state the payload and instruct execution now. Template:
+  > Your queued task is due. Execute the following queued work now, in order. If
+  > a step is a slash command, run it; otherwise treat it as an instruction.
+  >
+  > <QUEUED PAYLOAD>
+
+If the user passed no commands, ask what to queue — don't schedule an empty job.
+
+## Report back
+
+State: fire time (`FIRE_HUMAN`), the basis (`RESET_HUMAN`/`TARGET_HUMAN`),
+minutes away, the returned **job ID**, and the two caveats:
+- **Session-only** — keep this session/terminal open or the job dies with it.
+- **Fires only while the REPL is idle** — if you're mid-task at fire time, it
+  queues until the turn finishes.
+
+In reset mode, the fire time is keyed to the *last observed* window reset; if the
+real reset drifts slightly, the +90s/round-up cushion absorbs it.
+
+## Managing queued jobs
+
+- `CronList` — show what's scheduled this session.
+- `CronDelete <id>` — cancel a queued job.
+- Each `/queue` adds another one-shot; they don't replace each other.

--- a/skills/queue/scripts/compute-fire.sh
+++ b/skills/queue/scripts/compute-fire.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# compute-fire.sh — emit a one-shot cron spec (local time) for /queue.
+# macOS/BSD only: uses `date -r <epoch>` and `date -j -f` (GNU date differs).
+#
+# Modes:
+#   (default, no args)   Fire ~90s AFTER the current 5-hour usage window resets.
+#                        Reads resets_at + captured_at from the state file (kept
+#                        fresh by statusline-wrapper.sh). Rounds up to a whole
+#                        minute and DODGES :00/:30 — the minutes where CronCreate
+#                        applies up-to-90s-EARLY jitter to one-shots — so it can
+#                        never fire before the window actually resets. Flags
+#                        STALE if the statusline hasn't rendered recently.
+#
+#   --epoch <N>          Fire at the explicit local epoch N (a clock time / "in
+#                        2h" / "10am tomorrow" the caller already resolved).
+#                        Floored to the minute and honored; a sub-minute-FUTURE
+#                        target bumps to the next whole minute (cron is
+#                        minute-granular).
+#
+# Config (env): QUEUE_STATE_FILE (default ~/.claude/queue/state.json)
+# Prints KEY=VALUE lines on success; non-zero exit + stderr message on failure.
+set -u
+
+STATE_FILE="${QUEUE_STATE_FILE:-$HOME/.claude/queue/state.json}"
+STALE_SEC=90            # statusline refreshes ~every 10s; >90s ⇒ likely not rendering
+now="$(date +%s)"
+mode="reset"
+epoch=""
+
+if [ "${1:-}" = "--epoch" ]; then
+  mode="epoch"
+  epoch="${2:-}"
+  case "$epoch" in
+    ''|*[!0-9]*) echo "ERROR: --epoch needs an integer Unix timestamp, got '${epoch}'." >&2; exit 4 ;;
+  esac
+fi
+
+stale=""
+age=0
+if [ "$mode" = "reset" ]; then
+  if [ ! -f "$STATE_FILE" ]; then
+    echo "ERROR: no state file at $STATE_FILE — the statusline hasn't captured a reset time yet." >&2
+    echo "Fix: keep this terminal focused ~10-15s so the statusline renders once, then retry." >&2
+    exit 1
+  fi
+  resets_at="$(jq -r '.resets_at // empty' "$STATE_FILE" 2>/dev/null)"
+  if [ -z "$resets_at" ] || [ "$resets_at" = "null" ]; then
+    echo "ERROR: state file has no resets_at (rate_limits is Pro/Max-only, and appears after the first API response)." >&2
+    exit 2
+  fi
+  # Staleness from captured_at; default 0 so a missing/non-numeric value reads as
+  # very stale (not falsely fresh).
+  captured="$(jq -r '.captured_at // 0' "$STATE_FILE" 2>/dev/null)"
+  case "$captured" in ''|*[!0-9]*) captured=0 ;; esac
+  age=$(( now - captured ))
+  if [ "$age" -gt "$STALE_SEC" ]; then
+    stale="yes"
+    echo "WARNING: usage state is stale (${age}s old) — the statusline may not be rendering. Focus this terminal ~10-15s and re-run to refresh the reset time before relying on it." >&2
+  else
+    stale="no"
+  fi
+  # Fire 90s after reset, rounded UP to the next whole minute, dodging :00/:30.
+  # Use the LOCAL minute (date +%M) for the dodge so it stays correct in
+  # half-hour-offset timezones, where UTC minutes != local minutes.
+  fire=$(( resets_at + 90 ))
+  fire=$(( (fire + 59) / 60 * 60 ))
+  m=$(( 10#$(date -r "$fire" +%M) ))
+  if [ "$m" -eq 0 ] || [ "$m" -eq 30 ]; then
+    fire=$(( fire + 60 ))
+  fi
+  basis_label="RESET_HUMAN"
+  basis_human="$(date -r "$resets_at" '+%Y-%m-%d %H:%M:%S %Z')"
+else
+  # Explicit target: floor to the minute. A sub-minute FUTURE target (e.g. "in
+  # 30s") floors into the current minute — bump it to the next whole minute so
+  # cron has something to fire on. A genuinely past target falls to the guard.
+  fire=$(( epoch / 60 * 60 ))
+  if [ "$fire" -le "$now" ] && [ "$epoch" -gt "$now" ]; then
+    fire=$(( (now / 60 + 1) * 60 ))
+  fi
+  basis_label="TARGET_HUMAN"
+fi
+
+if [ "$fire" -le "$now" ]; then
+  if [ "$mode" = "epoch" ]; then
+    echo "ERROR: target $(date -r "$epoch" '+%Y-%m-%d %H:%M:%S %Z') is in the past. Cron resolves to whole minutes — pick a time ≥1 minute out, and resolve bare clock times to the next future occurrence." >&2
+  else
+    echo "ERROR: the 5h window already reset at $(date -r "$resets_at" '+%Y-%m-%d %H:%M:%S %Z'); nothing to wait for — run the commands now instead." >&2
+  fi
+  exit 3
+fi
+
+[ "$mode" = "epoch" ] && basis_human="$(date -r "$fire" '+%Y-%m-%d %H:%M %Z')"
+
+# Cron fields in LOCAL time. 10# forces base-10 so "08"/"09" aren't read as octal
+# and leading zeros are stripped (some cron parsers reject "09").
+M=$((  10#$(date -r "$fire" +%M) ))
+H=$((  10#$(date -r "$fire" +%H) ))
+DOM=$(( 10#$(date -r "$fire" +%d) ))
+MON=$(( 10#$(date -r "$fire" +%m) ))
+
+# DST spring-forward guard: if the fire wall-clock doesn't round-trip back to the
+# same epoch, it lands in a non-existent hour (e.g. 02:00-02:59 on the March
+# transition) and cron would never match. Warn — don't fail.
+wall="$(date -r "$fire" '+%Y-%m-%d %H:%M:00')"
+rt="$(date -j -f '%Y-%m-%d %H:%M:%S' "$wall" +%s 2>/dev/null)"
+if [ -n "$rt" ] && [ "$rt" != "$fire" ]; then
+  echo "WARNING: fire wall-clock $wall doesn't round-trip — likely a DST spring-forward gap; cron may never match. Nudge the time outside the 02:00-02:59 local hour." >&2
+fi
+
+secs=$(( fire - now ))
+echo "MODE=$mode"
+echo "CRON=$M $H $DOM $MON *"
+echo "FIRE_EPOCH=$fire"
+echo "FIRE_HUMAN=$(date -r "$fire" '+%Y-%m-%d %H:%M %Z')"
+echo "$basis_label=$basis_human"
+echo "SECONDS_AWAY=$secs"
+echo "MINUTES_AWAY=$(( secs / 60 ))"
+if [ "$mode" = "reset" ]; then
+  echo "CAPTURED_AGE_SEC=$age"
+  echo "STALE=$stale"
+fi

--- a/skills/queue/scripts/compute-fire.sh
+++ b/skills/queue/scripts/compute-fire.sh
@@ -43,11 +43,15 @@ if [ "$mode" = "reset" ]; then
     echo "Fix: keep this terminal focused ~10-15s so the statusline renders once, then retry." >&2
     exit 1
   fi
+  # Must be a bare integer epoch: it feeds `fire=$(( resets_at + 90 ))` below, so
+  # a non-numeric value (corrupt/hand-edited file) would otherwise reach
+  # arithmetic. Guard at read; the empty/"null"/garbage cases all land here.
   resets_at="$(jq -r '.resets_at // empty' "$STATE_FILE" 2>/dev/null)"
-  if [ -z "$resets_at" ] || [ "$resets_at" = "null" ]; then
-    echo "ERROR: state file has no resets_at (rate_limits is Pro/Max-only, and appears after the first API response)." >&2
-    exit 2
-  fi
+  case "$resets_at" in
+    ''|*[!0-9]*)
+      echo "ERROR: state file has no valid resets_at (rate_limits is Pro/Max-only, and appears after the first API response)." >&2
+      exit 2 ;;
+  esac
   # Staleness from captured_at; default 0 so a missing/non-numeric value reads as
   # very stale (not falsely fresh).
   captured="$(jq -r '.captured_at // 0' "$STATE_FILE" 2>/dev/null)"

--- a/skills/queue/scripts/statusline-wrapper.sh
+++ b/skills/queue/scripts/statusline-wrapper.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# statusline-wrapper.sh — taps the 5-hour usage-window reset time into a state
+# file on its way through to your real statusline renderer.
+#
+# Claude Code pipes a JSON blob to the statusLine command on stdin. For Pro/Max
+# subscribers it includes `rate_limits.five_hour.{resets_at,used_percentage}` —
+# the moment the current 5h usage window flips and how much is consumed. That
+# data is NOT available to anything running inside a session, so we capture it
+# here. Reads stdin once, persists to the state file, then forwards the SAME
+# stdin to the real renderer (default: ccstatusline) and prints its output.
+#
+# Config (env):
+#   QUEUE_STATE_FILE   where to write state (default ~/.claude/queue/state.json)
+#   QUEUE_STATUSLINE   the real statusline command to forward to
+#                      (default: bunx -y ccstatusline@latest)
+set -u
+
+STATE_FILE="${QUEUE_STATE_FILE:-$HOME/.claude/queue/state.json}"
+mkdir -p "$(dirname "$STATE_FILE")"
+
+input="$(cat)"
+
+# Tap the 5h window fields; only persist when resets_at is present and numeric.
+resets_at="$(printf '%s' "$input" | jq -r '.rate_limits.five_hour.resets_at // empty' 2>/dev/null)"
+if [ -n "$resets_at" ]; then
+  used="$(printf '%s' "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty' 2>/dev/null)"
+  now="$(date +%s)"
+  printf '{"resets_at":%s,"used_percentage":%s,"captured_at":%s}\n' \
+    "$resets_at" "${used:-null}" "$now" > "$STATE_FILE"
+fi
+
+# Forward original stdin to the real statusline renderer (output unchanged).
+printf '%s' "$input" | ${QUEUE_STATUSLINE:-bunx -y ccstatusline@latest}

--- a/skills/queue/scripts/statusline-wrapper.sh
+++ b/skills/queue/scripts/statusline-wrapper.sh
@@ -20,8 +20,13 @@ mkdir -p "$(dirname "$STATE_FILE")"
 
 input="$(cat)"
 
-# Tap the 5h window fields; only persist when resets_at is present and numeric.
+# Tap the 5h window fields; only persist when resets_at is present and a bare
+# integer epoch. Guarding here matters: resets_at is interpolated raw into the
+# JSON below, so a non-numeric value (e.g. an ISO-8601 string) would write a
+# corrupt, unparseable state file — worse than no file, since both consumers
+# would then jq-fail to empty and misreport the cause as "no resets_at".
 resets_at="$(printf '%s' "$input" | jq -r '.rate_limits.five_hour.resets_at // empty' 2>/dev/null)"
+case "$resets_at" in ''|*[!0-9]*) resets_at="" ;; esac
 if [ -n "$resets_at" ]; then
   used="$(printf '%s' "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty' 2>/dev/null)"
   now="$(date +%s)"

--- a/skills/queue/scripts/statusline-wrapper.sh
+++ b/skills/queue/scripts/statusline-wrapper.sh
@@ -28,10 +28,14 @@ input="$(cat)"
 resets_at="$(printf '%s' "$input" | jq -r '.rate_limits.five_hour.resets_at // empty' 2>/dev/null)"
 case "$resets_at" in ''|*[!0-9]*) resets_at="" ;; esac
 if [ -n "$resets_at" ]; then
+  # used_percentage is a float and is interpolated raw too — same corruption risk
+  # as resets_at. Keep only a bare number (digits + at most one dot); anything
+  # else (absent, or unexpected non-numeric) becomes JSON null.
   used="$(printf '%s' "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty' 2>/dev/null)"
+  case "$used" in ''|*[!0-9.]*|*.*.*) used="null" ;; esac
   now="$(date +%s)"
   printf '{"resets_at":%s,"used_percentage":%s,"captured_at":%s}\n' \
-    "$resets_at" "${used:-null}" "$now" > "$STATE_FILE"
+    "$resets_at" "$used" "$now" > "$STATE_FILE"
 fi
 
 # Forward original stdin to the real statusline renderer (output unchanged).

--- a/skills/usage-guard/README.md
+++ b/skills/usage-guard/README.md
@@ -1,0 +1,40 @@
+# usage-guard
+
+Work a task autonomously and continuously, checking 5-hour usage-window
+consumption at each checkpoint, and stop cleanly at a threshold (default 99%)
+instead of getting rate-limited mid-action.
+
+```
+/usage-guard [--queue] [--at <pct>] <task>
+```
+
+- **Default:** at the threshold, stop and report what's done + what's still open.
+- **`--queue`:** at the threshold, queue the remaining work to auto-resume in the
+  next 5-hour block. The continuation re-invokes `/usage-guard --queue`, so a task
+  bigger than one block chains block-to-block until the open list is empty.
+- **`--at <pct>`:** override the threshold.
+
+## Requirement
+
+Reads usage from the **`queue` skill's** state file (`~/.claude/queue/state.json`),
+kept fresh by its statusline wrapper. Set that up first — see `../queue/README.md`.
+`scripts/check-usage.sh` reads the file and exits `0` (under) / `10` (at/over) /
+`1|2` (no data). Honors `QUEUE_STATE_FILE`. macOS/BSD only.
+
+## How the stop works (honest limits)
+
+- **Checkpoint-granular, not a hard interrupt** — the model checks between work
+  chunks, so it stops at the first check at/after the threshold; actual usage may
+  be a hair above it. That's what the 1% headroom (default 99) is for, and why the
+  loop bounds chunk size near the ceiling.
+- **`--queue` chains use `durable: true`** so they survive a restart, but still
+  only fire while some Claude session is running and idle — not a headless runner.
+- A resumed block starts **cold**; the chain is only as good as the continuation
+  payload (the skill requires a fixed set of fields in it).
+
+## Files
+
+- `SKILL.md` — model-facing instructions (work loop, threshold branches, `--queue` chaining).
+- `scripts/check-usage.sh` — reads usage state, float-safe threshold compare, staleness signal.
+
+Tests: `tests/usage-guard/caliper-test_check_usage.sh`.

--- a/skills/usage-guard/SKILL.md
+++ b/skills/usage-guard/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: usage-guard
+description: Work a task autonomously and continuously, checking 5-hour usage-window consumption at each checkpoint, and stop when usage hits a threshold (default 99%) instead of getting rate-limited mid-action. Use when the user runs `/usage-guard <task>`, `/usage-guard --queue <task>`, says "keep going until I'm almost out of usage", "grind on this until the 5-hour limit", "use up my block on this", or "work until 99% then stop / then queue the rest".
+---
+
+# /usage-guard — work until the 5-hour usage window is nearly spent
+
+Run a task as a continuous autonomous work session, self-checking how much of
+the current 5-hour usage window has been consumed, and stop cleanly at a
+threshold (default **99%**) — leaving 1% headroom so the stop/report (or queue)
+actions don't trip a real rate limit mid-action.
+
+`/usage-guard [--queue] [--at <pct>] <task>`
+
+## Parse the invocation
+
+- `--queue` — at the threshold, don't just stop: queue the remaining work to
+  auto-resume in the next 5-hour block (see "At the threshold" below).
+- `--at <pct>` — override the threshold (e.g. `--at 95`). Default 99.
+- Everything else is the **TASK**. If no task is given, treat the current
+  in-progress work / the conversation's active objective as the task; if that's
+  unclear, ask what to grind on before starting.
+
+## How usage is read
+
+`./skills/usage-guard/scripts/check-usage.sh [threshold]` (invoke
+directly — executable, no `bash` prefix) reads `~/.claude/queue/state.json`,
+kept fresh by the queue skill's statusline wrapper. It prints `USED_PCT=`,
+`VERDICT=` (UNDER/OVER), `CAPTURED_AGE_SEC=`, `RESETS_AT_HUMAN=`, `RESETS_IN_MIN=`
+and exits **0 = under**, **10 = at/over**, **1/2 = data unavailable**.
+
+- This depends on the **queue skill's statusline wrapper** being wired in. If
+  check-usage exits 1/2, relay its stderr and stop — usage can't be read.
+- If `CAPTURED_AGE_SEC` is large (say > 120s), the reading is stale (statusline
+  hasn't rendered — terminal idle/unfocused). Note it; the number may lag.
+
+## The work loop
+
+1. **Set up a ledger.** Use the task list (TaskCreate/TaskUpdate) to break the
+   TASK into trackable sub-tasks and keep it current. This ledger IS your
+   "what's done / what's still open" for the stop report and the queue payload.
+2. **Do a chunk** of the work (a sub-task, or a small batch of steps).
+3. **Update the ledger** (mark finished items done) — do this *before* the usage
+   check so the check/branch always sees a current ledger.
+4. **Check usage** by running check-usage.sh:
+   - Exit 0 (UNDER) → continue to the next chunk.
+   - Exit 10 (OVER) → go to "At the threshold".
+   - Exit 1/2 → relay and stop.
+5. **Cadence AND chunk size** — the overshoot guard. Checking often isn't enough
+   if a single chunk between checks can itself burn several percent:
+   - Check after each sub-task while usage is low; past ~90% `USED_PCT`, check
+     after *every* step.
+   - Past ~90%, also keep chunks **small** — do NOT start a single long-running
+     action (big build, wide subagent fan-out, large batch) that could plausibly
+     consume more than the remaining headroom. If the next step might, check/stop
+     *before* it, not after.
+   - If `CAPTURED_AGE_SEC` is large near the ceiling, the reading is stale and
+     lags reality — treat it as a floor and stop early rather than trusting a
+     sub-threshold number.
+6. **If the task completes before the threshold** → stop and report it done; do
+   NOT queue. (A finished task ends the chain.)
+
+Work continuously without pausing to ask between chunks — that's the point of
+the guard. Only stop for the threshold, task completion, a hard error, or a
+genuine decision that's the user's to make.
+
+## At the threshold (VERDICT=OVER)
+
+First, make the ledger accurate (mark what's done; the open items are what
+remains). Then:
+
+**Default (no `--queue`):** stop now and report:
+- `USED_PCT` reached and that the window resets at `RESETS_AT_HUMAN`,
+- what got done this run,
+- what's still open (the remaining ledger items),
+- how to resume (a one-line "say continue / re-run with --queue" pointer).
+
+**With `--queue`:** queue the remainder to resume in the next block.
+
+- **First, the termination guard:** if no open ledger items remain, the task is
+  effectively done — report it done and do **NOT** queue. Only queue when real
+  work remains.
+
+1. Compose a **CONTINUATION PAYLOAD** — a self-contained resume prompt, because
+   the resumed session is **cold** (no task list, no file context, no memory of
+   this run except this string). It MUST include all of:
+   - (i) the **original task statement, verbatim** — so block N hasn't drifted;
+   - (ii) **done so far** (the completed ledger items);
+   - (iii) **still open** (the remaining ledger items, in order);
+   - (iv) **environment** — working directory, git branch/worktree, and key file
+     paths / IDs / URLs needed to resume;
+   - (v) **decisions & constraints** already settled this run.
+2. Get the fire time: `./skills/queue/scripts/compute-fire.sh`
+   (reset mode — fires ~90s after the window resets). Relay stderr and stop if
+   it errors; if it prints `STALE=yes`, refresh the statusline first.
+3. `CronCreate` with: `cron` = its `CRON` value, `recurring: false`,
+   **`durable: true`** (a multi-block chain almost always outlives this terminal,
+   so persist it — unlike a plain `/queue`, which defaults session-only), and
+   `prompt`:
+   > Your queued usage-guarded work is due — the 5-hour window has reset. First
+   > `cd` to the working directory named below. Then resume by invoking
+   > `/usage-guard --queue` on the following remaining work, so it keeps guarding
+   > usage and re-queues anything still open at the next threshold:
+   >
+   > <CONTINUATION PAYLOAD>
+4. Report: what got done, that the rest is queued for `FIRE_HUMAN` (job ID), and
+   the caveats below. Because the continuation re-invokes `/usage-guard --queue`,
+   a task bigger than one block chains block-to-block until the open list is
+   empty (the termination guard above is what ends it).
+
+## Caveats (state these when stopping)
+
+- **Checkpoint-granular, not a hard interrupt** — the stop lands at the first
+  check at/after the threshold, so actual usage may be a hair above it. That's
+  what the 1% headroom is for.
+- **`--queue` chains are `durable: true`** — they persist to disk and survive a
+  restart (a 5h+ chain won't keep one terminal open). But a durable job still
+  only fires **while some Claude session is running and idle** — if nothing is
+  running at reset time it fires late, when you next open Claude. It is not a
+  headless/background runner. `CronList` / `CronDelete <id>` to inspect or cancel.
+- The continuation resumes **cold** in whatever session fires it — its quality is
+  only as good as the CONTINUATION PAYLOAD (hence the required fields above).

--- a/skills/usage-guard/SKILL.md
+++ b/skills/usage-guard/SKILL.md
@@ -26,13 +26,14 @@ actions don't trip a real rate limit mid-action.
 `./skills/usage-guard/scripts/check-usage.sh [threshold]` (invoke
 directly — executable, no `bash` prefix) reads `~/.claude/queue/state.json`,
 kept fresh by the queue skill's statusline wrapper. It prints `USED_PCT=`,
-`VERDICT=` (UNDER/OVER), `CAPTURED_AGE_SEC=`, `RESETS_AT_HUMAN=`, `RESETS_IN_MIN=`
-and exits **0 = under**, **10 = at/over**, **1/2 = data unavailable**.
+`VERDICT=` (UNDER/OVER), `CAPTURED_AGE_SEC=`, `STALE=` (yes/no), `RESETS_AT_HUMAN=`,
+`RESETS_IN_MIN=` and exits **0 = under**, **10 = at/over**, **1/2 = data unavailable**.
 
 - This depends on the **queue skill's statusline wrapper** being wired in. If
   check-usage exits 1/2, relay its stderr and stop — usage can't be read.
-- If `CAPTURED_AGE_SEC` is large (say > 120s), the reading is stale (statusline
-  hasn't rendered — terminal idle/unfocused). Note it; the number may lag.
+- `STALE=yes` (the same >90s cutoff `compute-fire.sh` uses) means the statusline
+  hasn't rendered recently — terminal idle/unfocused — so `USED_PCT` lags reality.
+  Note it; the number may be behind.
 
 ## The work loop
 
@@ -54,9 +55,9 @@ and exits **0 = under**, **10 = at/over**, **1/2 = data unavailable**.
      action (big build, wide subagent fan-out, large batch) that could plausibly
      consume more than the remaining headroom. If the next step might, check/stop
      *before* it, not after.
-   - If `CAPTURED_AGE_SEC` is large near the ceiling, the reading is stale and
-     lags reality — treat it as a floor and stop early rather than trusting a
-     sub-threshold number.
+   - If `STALE=yes` near the ceiling, the reading lags reality — treat
+     `USED_PCT` as a floor and stop early rather than trusting a sub-threshold
+     number.
 6. **If the task completes before the threshold** → stop and report it done; do
    NOT queue. (A finished task ends the chain.)
 

--- a/skills/usage-guard/scripts/check-usage.sh
+++ b/skills/usage-guard/scripts/check-usage.sh
@@ -14,13 +14,15 @@
 #
 # CAPTURED_AGE_SEC is the staleness signal: large ⇒ the statusline isn't
 # rendering and USED_PCT lags reality. A missing captured_at reports as very
-# stale (not falsely fresh).
+# stale (not falsely fresh). STALE=yes|no applies the same >90s cutoff as
+# compute-fire.sh, so both consumers of captured_at agree on one threshold.
 #
 # Config (env): QUEUE_STATE_FILE (default ~/.claude/queue/state.json)
 set -u
 
 STATE_FILE="${QUEUE_STATE_FILE:-$HOME/.claude/queue/state.json}"
 THRESH="${1:-99}"
+STALE_SEC=90            # statusline refreshes ~every 10s; >90s ⇒ likely not rendering
 
 if [ ! -f "$STATE_FILE" ]; then
   echo "ERROR: no $STATE_FILE — the queue statusline wrapper isn't capturing usage yet." >&2
@@ -47,6 +49,7 @@ used_disp="$(awk -v u="$used" 'BEGIN{ printf "%.1f", u+0 }')"
 echo "USED_PCT=$used_disp"
 echo "THRESHOLD=$THRESH"
 echo "CAPTURED_AGE_SEC=$age"
+if [ "$age" -gt "$STALE_SEC" ]; then echo "STALE=yes"; else echo "STALE=no"; fi
 if [ -n "$resets_at" ] && [ "$resets_at" != "null" ]; then
   echo "RESETS_AT_HUMAN=$(date -r "$resets_at" '+%Y-%m-%d %H:%M %Z')"
   echo "RESETS_IN_MIN=$(( (resets_at - now) / 60 ))"

--- a/skills/usage-guard/scripts/check-usage.sh
+++ b/skills/usage-guard/scripts/check-usage.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# check-usage.sh [threshold]   (threshold default 99)
+# macOS/BSD only: uses `date -r <epoch>`.
+#
+# Reports the current Claude 5-hour usage-window consumption by reading the
+# queue skill's state file — refreshed (~every 10s) by statusline-wrapper.sh
+# with rate_limits.five_hour.{used_percentage,resets_at}.
+#
+# Exit codes let a caller branch without parsing floats:
+#   0  = UNDER threshold (keep going)
+#   10 = AT/OVER threshold (stop / queue)
+#   1  = no state file (wrapper not wired in, or no render yet)
+#   2  = no used_percentage (Pro/Max only, appears after first API response)
+#
+# CAPTURED_AGE_SEC is the staleness signal: large ⇒ the statusline isn't
+# rendering and USED_PCT lags reality. A missing captured_at reports as very
+# stale (not falsely fresh).
+#
+# Config (env): QUEUE_STATE_FILE (default ~/.claude/queue/state.json)
+set -u
+
+STATE_FILE="${QUEUE_STATE_FILE:-$HOME/.claude/queue/state.json}"
+THRESH="${1:-99}"
+
+if [ ! -f "$STATE_FILE" ]; then
+  echo "ERROR: no $STATE_FILE — the queue statusline wrapper isn't capturing usage yet." >&2
+  echo "Fix: settings.json statusLine must point to the queue statusline-wrapper.sh; let the terminal render once." >&2
+  exit 1
+fi
+
+used="$(jq -r '.used_percentage // empty' "$STATE_FILE" 2>/dev/null)"
+resets_at="$(jq -r '.resets_at // empty' "$STATE_FILE" 2>/dev/null)"
+captured="$(jq -r '.captured_at // 0' "$STATE_FILE" 2>/dev/null)"
+if [ -z "$used" ]; then
+  echo "ERROR: no used_percentage in state file (Pro/Max only, after first API response)." >&2
+  exit 2
+fi
+case "$captured" in ''|*[!0-9]*) captured=0 ;; esac
+
+now="$(date +%s)"
+age=$(( now - captured ))
+
+# Display value rounded to 1 decimal (statusline can carry float noise like
+# 28.000000000000004); keep raw $used for the threshold compare.
+used_disp="$(awk -v u="$used" 'BEGIN{ printf "%.1f", u+0 }')"
+
+echo "USED_PCT=$used_disp"
+echo "THRESHOLD=$THRESH"
+echo "CAPTURED_AGE_SEC=$age"
+if [ -n "$resets_at" ] && [ "$resets_at" != "null" ]; then
+  echo "RESETS_AT_HUMAN=$(date -r "$resets_at" '+%Y-%m-%d %H:%M %Z')"
+  echo "RESETS_IN_MIN=$(( (resets_at - now) / 60 ))"
+fi
+
+# Float-safe comparison (used_percentage may be e.g. 92.7).
+verdict="$(awk -v u="$used" -v t="$THRESH" 'BEGIN{ print (u+0 >= t+0) ? "OVER" : "UNDER" }')"
+echo "VERDICT=$verdict"
+[ "$verdict" = "OVER" ] && exit 10 || exit 0

--- a/skills/usage-guard/scripts/check-usage.sh
+++ b/skills/usage-guard/scripts/check-usage.sh
@@ -33,10 +33,17 @@ fi
 used="$(jq -r '.used_percentage // empty' "$STATE_FILE" 2>/dev/null)"
 resets_at="$(jq -r '.resets_at // empty' "$STATE_FILE" 2>/dev/null)"
 captured="$(jq -r '.captured_at // 0' "$STATE_FILE" 2>/dev/null)"
-if [ -z "$used" ]; then
-  echo "ERROR: no used_percentage in state file (Pro/Max only, after first API response)." >&2
-  exit 2
-fi
+# Fail closed on a missing/non-numeric used_percentage: a non-number would make
+# the awk compare below read 0 and report a false UNDER — exactly the verdict
+# that would let the guard run past the limit. exit 2 (data unavailable) instead.
+case "$used" in
+  ''|*[!0-9.]*|*.*.*)
+    echo "ERROR: missing or non-numeric used_percentage in state file (Pro/Max only, after first API response)." >&2
+    exit 2 ;;
+esac
+# resets_at is only used for the human/RESETS_IN lines; a non-integer reads as
+# absent so we skip those rather than emit garbage or hit a date error.
+case "$resets_at" in *[!0-9]*) resets_at="" ;; esac
 case "$captured" in ''|*[!0-9]*) captured=0 ;; esac
 
 now="$(date +%s)"
@@ -50,7 +57,7 @@ echo "USED_PCT=$used_disp"
 echo "THRESHOLD=$THRESH"
 echo "CAPTURED_AGE_SEC=$age"
 if [ "$age" -gt "$STALE_SEC" ]; then echo "STALE=yes"; else echo "STALE=no"; fi
-if [ -n "$resets_at" ] && [ "$resets_at" != "null" ]; then
+if [ -n "$resets_at" ]; then
   echo "RESETS_AT_HUMAN=$(date -r "$resets_at" '+%Y-%m-%d %H:%M %Z')"
   echo "RESETS_IN_MIN=$(( (resets_at - now) / 60 ))"
 fi

--- a/tests/queue/caliper-test_compute_fire.sh
+++ b/tests/queue/caliper-test_compute_fire.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Tests for skills/queue/scripts/compute-fire.sh
+# macOS/BSD only (uses `date -r <epoch>`); skips on GNU date (e.g. Linux CI).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HELPER="$REPO_ROOT/skills/queue/scripts/compute-fire.sh"
+
+# Skip gracefully where `date -r <epoch>` isn't BSD semantics.
+if ! date -r 0 >/dev/null 2>&1; then
+  echo "SKIP: compute-fire.sh requires BSD date (-r epoch); not available here."
+  exit 0
+fi
+
+pass=0; fail=0
+STATE="$(mktemp)"; trap 'rm -f "$STATE"' EXIT
+now="$(date +%s)"
+
+# Run HELPER with QUEUE_STATE_FILE pointed at our temp state; capture out/err/rc.
+run() {
+  local tmp_out tmp_err
+  tmp_out="$(mktemp)"; tmp_err="$(mktemp)"
+  set +e
+  env QUEUE_STATE_FILE="$STATE" PATH="$PATH" HOME="$HOME" bash "$HELPER" "$@" \
+    >"$tmp_out" 2>"$tmp_err"
+  RC=$?
+  set -e
+  STDOUT="$(cat "$tmp_out")"; STDERR="$(cat "$tmp_err")"
+  rm -f "$tmp_out" "$tmp_err"
+}
+assert() {
+  local desc="$1" cond="$2"
+  if eval "$cond"; then echo "PASS: $desc"; pass=$((pass+1))
+  else echo "FAIL: $desc"; echo "  STDOUT: $STDOUT"; echo "  STDERR: $STDERR"; echo "  RC: $RC"; fail=$((fail+1)); fi
+}
+field() { echo "$STDOUT" | sed -n "s/^$1=//p"; }            # value of a KEY=
+lmin()  { echo $(( 10#$(date -r "$1" +%M) )); }             # local minute of an epoch
+mkstate() { printf '%s' "$1" > "$STATE"; }
+
+# --- reset mode: basic ---
+future=$(( (now/3600 + 2)*3600 + 17*60 ))                   # a future :17 local, hours out
+mkstate "{\"resets_at\":$future,\"used_percentage\":40,\"captured_at\":$now}"
+run
+assert "reset mode exits 0"            '[[ $RC -eq 0 ]]'
+assert "reset mode reports MODE=reset" '[[ "$(field MODE)" == "reset" ]]'
+assert "reset mode emits a CRON"       '[[ -n "$(field CRON)" ]]'
+assert "fresh capture -> STALE=no"     '[[ "$(field STALE)" == "no" ]]'
+
+# --- reset mode: :30 dodge (reset+90 rounds onto a local :30) ---
+base=$(( (now/60 + 5)*60 ))                                 # minute-aligned, future
+while [ "$(lmin "$base")" -ne 30 ]; do base=$((base+60)); done
+mkstate "{\"resets_at\":$(( base - 120 )),\"captured_at\":$now}"   # +90 = base-30s -> roundup = base (:30)
+run
+dodged_min="$(field CRON | cut -d' ' -f1)"
+assert ":30 reset dodges to :31"   '[[ "$dodged_min" -eq 31 ]]'
+assert "dodge never lands on :00/:30" '[[ "$dodged_min" -ne 0 && "$dodged_min" -ne 30 ]]'
+
+# --- reset mode: stale capture ---
+mkstate "{\"resets_at\":$future,\"used_percentage\":40,\"captured_at\":$(( now - 600 ))}"
+run
+assert "stale capture -> STALE=yes"      '[[ "$(field STALE)" == "yes" ]]'
+assert "stale capture still exits 0"     '[[ $RC -eq 0 ]]'
+assert "stale capture warns on stderr"   '[[ "$STDERR" == *"stale"* ]]'
+
+# --- reset mode: missing / no data ---
+mkstate '{"used_percentage":40,"captured_at":'"$now"'}'
+run
+assert "missing resets_at -> exit 2" '[[ $RC -eq 2 ]]'
+rm -f "$STATE"
+run
+assert "no state file -> exit 1"     '[[ $RC -eq 1 ]]'
+
+# --- epoch mode ---
+tgt=$(( (now/3600 + 3)*3600 + 12*60 ))                      # future :12 local
+run --epoch "$tgt"
+assert "epoch mode exits 0"               '[[ $RC -eq 0 ]]'
+assert "epoch mode reports MODE=epoch"    '[[ "$(field MODE)" == "epoch" ]]'
+assert "epoch minute honored"             "[[ \"\$(field CRON | cut -d' ' -f1)\" -eq $(lmin "$tgt") ]]"
+
+# sub-minute future target bumps to the next whole minute (cron is minute-granular)
+nowx="$(date +%s)"; run --epoch "$(( nowx + 20 ))"
+assert "sub-minute target exits 0"        '[[ $RC -eq 0 ]]'
+assert "sub-minute bumps to next minute"  "[[ \$(field FIRE_EPOCH) -ge \$(( (nowx/60 + 1)*60 )) ]]"
+
+# genuinely-past target -> exit 3 with minute-granular message
+run --epoch "$(( now - 300 ))"
+assert "past epoch -> exit 3"             '[[ $RC -eq 3 ]]'
+assert "past epoch message mentions minutes" '[[ "$STDERR" == *"whole minutes"* ]]'
+
+# bad --epoch -> exit 4
+run --epoch "abc"
+assert "non-integer --epoch -> exit 4"    '[[ $RC -eq 4 ]]'
+
+echo "----"
+echo "compute-fire: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tests/queue/caliper-test_compute_fire.sh
+++ b/tests/queue/caliper-test_compute_fire.sh
@@ -66,6 +66,10 @@ assert "stale capture warns on stderr"   '[[ "$STDERR" == *"stale"* ]]'
 mkstate '{"used_percentage":40,"captured_at":'"$now"'}'
 run
 assert "missing resets_at -> exit 2" '[[ $RC -eq 2 ]]'
+# non-integer resets_at is rejected at read, before it can reach arithmetic
+mkstate "{\"resets_at\":\"2026-06-24T21:00:00Z\",\"captured_at\":$now}"
+run
+assert "non-integer resets_at -> exit 2" '[[ $RC -eq 2 ]]'
 rm -f "$STATE"
 run
 assert "no state file -> exit 1"     '[[ $RC -eq 1 ]]'

--- a/tests/queue/caliper-test_statusline_seam.sh
+++ b/tests/queue/caliper-test_statusline_seam.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Integration test for the state-file contract: statusline-wrapper.sh (the sole
+# PRODUCER) -> ~/.claude/queue/state.json -> compute-fire.sh + check-usage.sh
+# (the two CONSUMERS). Unit tests cover each consumer with hand-built fixtures;
+# this one feeds a representative Claude Code statusline JSON blob through the
+# real wrapper and then runs both consumers against the file it actually wrote,
+# so the producer/consumer JSON shape is verified end-to-end (not mocked).
+#
+# macOS/BSD only: the consumers use `date -r <epoch>`; skips on GNU date.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WRAPPER="$REPO_ROOT/skills/queue/scripts/statusline-wrapper.sh"
+COMPUTE_FIRE="$REPO_ROOT/skills/queue/scripts/compute-fire.sh"
+CHECK_USAGE="$REPO_ROOT/skills/usage-guard/scripts/check-usage.sh"
+
+# The consumers require BSD `date -r <epoch>`; skip the whole seam if absent.
+if ! date -r 0 >/dev/null 2>&1; then
+  echo "SKIP: state-file seam test requires BSD date (-r epoch); not available here."
+  exit 0
+fi
+
+pass=0; fail=0
+STATE="$(mktemp)"; rm -f "$STATE"            # start with NO file; wrapper creates it
+trap 'rm -f "$STATE"' EXIT
+now="$(date +%s)"
+future=$(( (now/3600 + 2)*3600 + 17*60 ))    # a future :17 local, hours out
+
+assert() {
+  local desc="$1" cond="$2"
+  if eval "$cond"; then echo "PASS: $desc"; pass=$((pass+1))
+  else echo "FAIL: $desc"; echo "  cond: $cond"; fail=$((fail+1)); fi
+}
+
+# Pipe a statusline JSON blob through the real wrapper. QUEUE_STATUSLINE=cat
+# both avoids invoking the default ccstatusline (network) and lets us assert the
+# wrapper forwards stdin unchanged. Returns the renderer's stdout in FWD.
+produce() {
+  rm -f "$STATE"
+  FWD="$(printf '%s' "$1" | env QUEUE_STATE_FILE="$STATE" QUEUE_STATUSLINE="cat" \
+    PATH="$PATH" HOME="$HOME" bash "$WRAPPER")"
+}
+# Run a consumer against whatever the wrapper wrote; capture out/err/rc.
+run() {
+  local helper="$1"; shift
+  local tmp_out tmp_err
+  tmp_out="$(mktemp)"; tmp_err="$(mktemp)"
+  set +e
+  env QUEUE_STATE_FILE="$STATE" PATH="$PATH" HOME="$HOME" bash "$helper" "$@" \
+    >"$tmp_out" 2>"$tmp_err"
+  RC=$?
+  set -e
+  STDOUT="$(cat "$tmp_out")"; STDERR="$(cat "$tmp_err")"
+  rm -f "$tmp_out" "$tmp_err"
+}
+field() { echo "$STDOUT" | sed -n "s/^$1=//p"; }
+
+# --- Producer writes a consumable state file from a full blob ---
+blob="{\"rate_limits\":{\"five_hour\":{\"resets_at\":$future,\"used_percentage\":40.5}},\"model\":{\"id\":\"x\"}}"
+produce "$blob"
+assert "wrapper creates the state file"        '[[ -f "$STATE" ]]'
+assert "wrapper writes valid JSON"             'jq -e . "$STATE" >/dev/null'
+assert "state resets_at matches input"         "[[ \"\$(jq -r .resets_at \"\$STATE\")\" == \"$future\" ]]"
+assert "state used_percentage matches input"   '[[ "$(jq -r .used_percentage "$STATE")" == "40.5" ]]'
+assert "state captured_at is recent"           '[[ "$(jq -r .captured_at "$STATE")" -ge '"$(( now - 5 ))"' ]]'
+assert "wrapper forwards stdin unchanged"       '[[ "$FWD" == "$blob" ]]'
+
+# --- Consumer 1: compute-fire consumes the real producer output ---
+run "$COMPUTE_FIRE"
+assert "compute-fire consumes wrapper output (exit 0)" '[[ $RC -eq 0 ]]'
+assert "compute-fire MODE=reset"                       '[[ "$(field MODE)" == "reset" ]]'
+assert "compute-fire emits a CRON"                     '[[ -n "$(field CRON)" ]]'
+assert "compute-fire sees fresh capture (STALE=no)"    '[[ "$(field STALE)" == "no" ]]'
+
+# --- Consumer 2: check-usage consumes the real producer output ---
+run "$CHECK_USAGE"
+assert "check-usage consumes wrapper output (exit 0 under 99)" '[[ $RC -eq 0 ]]'
+assert "check-usage reads the used_percentage (40.5)"          '[[ "$(field USED_PCT)" == "40.5" ]]'
+assert "check-usage VERDICT=UNDER"                             '[[ "$(field VERDICT)" == "UNDER" ]]'
+assert "check-usage emits STALE=no on fresh capture"           '[[ "$(field STALE)" == "no" ]]'
+
+# --- Producer emits used_percentage:null when the field is absent ---
+# (the shape the consumer unit-tests hand-build as a missing key — assert the
+#  wrapper's REAL output is what the consumers actually face.)
+produce "{\"rate_limits\":{\"five_hour\":{\"resets_at\":$future}}}"
+assert "wrapper always writes used_percentage key"  '[[ "$(jq -r "has(\"used_percentage\")" "$STATE")" == "true" ]]'
+assert "absent used_percentage -> null"             '[[ "$(jq -r .used_percentage "$STATE")" == "null" ]]'
+run "$COMPUTE_FIRE"
+assert "compute-fire still works without used_pct"  '[[ $RC -eq 0 ]]'
+run "$CHECK_USAGE"
+assert "check-usage -> exit 2 on null used_pct"     '[[ $RC -eq 2 ]]'
+
+# --- Producer guards a non-numeric resets_at instead of writing corrupt JSON ---
+# Without the guard, an ISO-8601 resets_at would be interpolated raw and produce
+# an unparseable file that misleads both consumers.
+produce "{\"rate_limits\":{\"five_hour\":{\"resets_at\":\"2026-06-24T21:00:00Z\",\"used_percentage\":40}}}"
+assert "non-numeric resets_at -> no state file written" '[[ ! -f "$STATE" ]]'
+run "$COMPUTE_FIRE"
+assert "compute-fire reports no-data (exit 1) not corruption" '[[ $RC -eq 1 ]]'
+
+# --- No rate_limits at all (free tier / pre-first-response): nothing written ---
+produce '{"model":{"id":"x"}}'
+assert "blob without rate_limits -> no state file" '[[ ! -f "$STATE" ]]'
+
+echo "----"
+echo "statusline-seam: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tests/queue/caliper-test_statusline_seam.sh
+++ b/tests/queue/caliper-test_statusline_seam.sh
@@ -90,6 +90,13 @@ assert "compute-fire still works without used_pct"  '[[ $RC -eq 0 ]]'
 run "$CHECK_USAGE"
 assert "check-usage -> exit 2 on null used_pct"     '[[ $RC -eq 2 ]]'
 
+# --- Producer sanitizes a non-numeric used_percentage to null (still valid JSON) ---
+produce "{\"rate_limits\":{\"five_hour\":{\"resets_at\":$future,\"used_percentage\":\"N/A\"}}}"
+assert "non-numeric used_percentage -> still valid JSON" 'jq -e . "$STATE" >/dev/null'
+assert "non-numeric used_percentage -> null"             '[[ "$(jq -r .used_percentage "$STATE")" == "null" ]]'
+run "$CHECK_USAGE"
+assert "check-usage -> exit 2 on sanitized-null used_pct" '[[ $RC -eq 2 ]]'
+
 # --- Producer guards a non-numeric resets_at instead of writing corrupt JSON ---
 # Without the guard, an ISO-8601 resets_at would be interpolated raw and produce
 # an unparseable file that misleads both consumers.

--- a/tests/usage-guard/caliper-test_check_usage.sh
+++ b/tests/usage-guard/caliper-test_check_usage.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Tests for skills/usage-guard/scripts/check-usage.sh
+# macOS/BSD only (uses `date -r <epoch>`); skips on GNU date (e.g. Linux CI).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HELPER="$REPO_ROOT/skills/usage-guard/scripts/check-usage.sh"
+
+if ! date -r 0 >/dev/null 2>&1; then
+  echo "SKIP: check-usage.sh requires BSD date (-r epoch); not available here."
+  exit 0
+fi
+
+pass=0; fail=0
+STATE="$(mktemp)"; trap 'rm -f "$STATE"' EXIT
+now="$(date +%s)"
+
+run() {
+  local tmp_out tmp_err
+  tmp_out="$(mktemp)"; tmp_err="$(mktemp)"
+  set +e
+  env QUEUE_STATE_FILE="$STATE" PATH="$PATH" HOME="$HOME" bash "$HELPER" "$@" \
+    >"$tmp_out" 2>"$tmp_err"
+  RC=$?
+  set -e
+  STDOUT="$(cat "$tmp_out")"; STDERR="$(cat "$tmp_err")"
+  rm -f "$tmp_out" "$tmp_err"
+}
+assert() {
+  local desc="$1" cond="$2"
+  if eval "$cond"; then echo "PASS: $desc"; pass=$((pass+1))
+  else echo "FAIL: $desc"; echo "  STDOUT: $STDOUT"; echo "  STDERR: $STDERR"; echo "  RC: $RC"; fail=$((fail+1)); fi
+}
+field() { echo "$STDOUT" | sed -n "s/^$1=//p"; }
+mkstate() { printf '%s' "$1" > "$STATE"; }
+
+reset=$(( now + 3600 ))
+
+# --- under threshold ---
+mkstate "{\"resets_at\":$reset,\"used_percentage\":42.7,\"captured_at\":$now}"
+run
+assert "under threshold -> exit 0"      '[[ $RC -eq 0 ]]'
+assert "under -> VERDICT=UNDER"         '[[ "$(field VERDICT)" == "UNDER" ]]'
+
+# --- at/over threshold (default 99) ---
+mkstate "{\"resets_at\":$reset,\"used_percentage\":99.4,\"captured_at\":$now}"
+run
+assert "over threshold -> exit 10"      '[[ $RC -eq 10 ]]'
+assert "over -> VERDICT=OVER"           '[[ "$(field VERDICT)" == "OVER" ]]'
+
+# exactly at threshold counts as OVER
+mkstate "{\"resets_at\":$reset,\"used_percentage\":99,\"captured_at\":$now}"
+run
+assert "exactly 99 -> exit 10 (at-or-over)" '[[ $RC -eq 10 ]]'
+
+# --- custom threshold ---
+mkstate "{\"resets_at\":$reset,\"used_percentage\":96,\"captured_at\":$now}"
+run 95
+assert "used 96 vs --at 95 -> exit 10"  '[[ $RC -eq 10 ]]'
+run 99
+assert "used 96 vs default 99 -> exit 0" '[[ $RC -eq 0 ]]'
+
+# --- float display rounding (raw value still drives the compare) ---
+mkstate "{\"resets_at\":$reset,\"used_percentage\":28.000000000000004,\"captured_at\":$now}"
+run
+assert "float noise displays as 28.0"   '[[ "$(field USED_PCT)" == "28.0" ]]'
+assert "float value still UNDER (exit 0)" '[[ $RC -eq 0 ]]'
+
+# --- staleness: missing captured_at reads as very stale, not fresh 0 (regression) ---
+mkstate "{\"resets_at\":$reset,\"used_percentage\":50}"
+run
+assert "missing captured_at -> huge age" '[[ "$(field CAPTURED_AGE_SEC)" -gt 1000000 ]]'
+
+# --- no data ---
+mkstate '{"resets_at":'"$reset"'}'
+run
+assert "missing used_percentage -> exit 2" '[[ $RC -eq 2 ]]'
+rm -f "$STATE"
+run
+assert "no state file -> exit 1"        '[[ $RC -eq 1 ]]'
+
+echo "----"
+echo "check-usage: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tests/usage-guard/caliper-test_check_usage.sh
+++ b/tests/usage-guard/caliper-test_check_usage.sh
@@ -77,6 +77,16 @@ assert "missing captured_at -> STALE=yes" '[[ "$(field STALE)" == "yes" ]]'
 mkstate '{"resets_at":'"$reset"'}'
 run
 assert "missing used_percentage -> exit 2" '[[ $RC -eq 2 ]]'
+
+# non-numeric used_percentage fails CLOSED (exit 2), never a false UNDER that
+# would let the guard run past the limit.
+mkstate "{\"resets_at\":$reset,\"used_percentage\":\"garbage\",\"captured_at\":$now}"
+run
+assert "non-numeric used_percentage -> exit 2"  '[[ $RC -eq 2 ]]'
+mkstate "{\"resets_at\":$reset,\"used_percentage\":\"9.9.9\",\"captured_at\":$now}"
+run
+assert "multi-dot used_percentage -> exit 2"    '[[ $RC -eq 2 ]]'
+
 rm -f "$STATE"
 run
 assert "no state file -> exit 1"        '[[ $RC -eq 1 ]]'

--- a/tests/usage-guard/caliper-test_check_usage.sh
+++ b/tests/usage-guard/caliper-test_check_usage.sh
@@ -41,6 +41,7 @@ mkstate "{\"resets_at\":$reset,\"used_percentage\":42.7,\"captured_at\":$now}"
 run
 assert "under threshold -> exit 0"      '[[ $RC -eq 0 ]]'
 assert "under -> VERDICT=UNDER"         '[[ "$(field VERDICT)" == "UNDER" ]]'
+assert "fresh capture -> STALE=no"      '[[ "$(field STALE)" == "no" ]]'
 
 # --- at/over threshold (default 99) ---
 mkstate "{\"resets_at\":$reset,\"used_percentage\":99.4,\"captured_at\":$now}"
@@ -70,6 +71,7 @@ assert "float value still UNDER (exit 0)" '[[ $RC -eq 0 ]]'
 mkstate "{\"resets_at\":$reset,\"used_percentage\":50}"
 run
 assert "missing captured_at -> huge age" '[[ "$(field CAPTURED_AGE_SEC)" -gt 1000000 ]]'
+assert "missing captured_at -> STALE=yes" '[[ "$(field STALE)" == "yes" ]]'
 
 # --- no data ---
 mkstate '{"resets_at":'"$reset"'}'


### PR DESCRIPTION
## Summary
- Add two macOS-only skills for working around Claude's 5-hour usage window:
  - **queue** — schedule commands to fire later in the same session via a one-shot `CronCreate`, defaulting to ~90s after the current 5h window resets (fresh quota), or at an explicit time/duration. Depends on a thin `statusLine` wrapper that taps `rate_limits.five_hour.{resets_at,used_percentage}` into a state file.
  - **usage-guard** — work a task autonomously, checking 5h consumption at each checkpoint via the same state file, and stop (or `--queue` the remainder into the next block) at a threshold (default 99%).
- Wire both into the `claude-caliper` (full) and `claude-caliper-tooling` bundles; bump bundle versions; document in README.md and CLAUDE.md.
- Both consumers share one state-file contract (`~/.claude/queue/state.json`); the wrapper is the sole producer.

## Implementation review fixes (commit 460b0c0)
A standalone implementation review surfaced four cross-component issues, all fixed:
- Added a producer→consumer integration test (`tests/queue/caliper-test_statusline_seam.sh`) that feeds a real statusline JSON blob through the wrapper, then runs both consumers against the file it actually wrote — closing a seam previously covered only by hand-built fixtures (the wrapper had zero tests).
- Hardened the wrapper to guard `resets_at` to a bare integer epoch before interpolating it into JSON (a non-numeric value can no longer write a corrupt state file).
- Unified the staleness threshold: `check-usage.sh` now emits `STALE=yes|no` on the same >90s cutoff as `compute-fire.sh`; the SKILL.md references that verdict instead of a contradictory "120s".
- Corrected README bundle skill counts (15 / 10 / 5).

## Test plan
- macOS suite (BSD `date`): seam 21, compute-fire 19, check-usage 14 — all pass.
- These skills are intentionally **not** wired into the Linux CI job (they `date -r 0` guard and SKIP on GNU date); the new seam test follows the same pattern.
- CI-relevant tests (hooks, validate-plan) run clean locally.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new scheduling-related skills for managing work around Claude usage windows.
  * Introduced support for deferring tasks until a later time and for pausing work before usage limits are reached.
* **Documentation**
  * Expanded setup and usage guidance for the new scheduling workflows.
  * Added notes about platform-specific behavior and required configuration.
* **Tests**
  * Added coverage for scheduling, usage checks, and state-file integration across the new workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->