### PR TITLE
feat(queue): wrapper renders its own statusline; ccstatusline now opt-in

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.50.0",
+      "version": "1.51.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -59,7 +59,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit, test audit, skill evaluation, and usage-window scheduling (queue / usage-guard)",
-      "version": "1.49.0",
+      "version": "1.50.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/skills/queue/README.md
+++ b/skills/queue/README.md
@@ -16,9 +16,12 @@ command's stdin — not in any file or CLI. So reset-mode depends on a thin
 statusline wrapper that captures those fields to a state file on the way through
 to your real statusline renderer.
 
-`scripts/statusline-wrapper.sh` does exactly that: it reads stdin once, writes
-`{resets_at, used_percentage, captured_at}` to the state file, then forwards the
-same stdin to your renderer (default `bunx -y ccstatusline@latest`) unchanged.
+`scripts/statusline-wrapper.sh` does exactly that: it reads stdin once and writes
+`{resets_at, used_percentage, captured_at}` to the state file. It then renders the
+statusline itself — a compact `dir (branch) · model · 5h NN% (resets HH:MM)`
+line — so **no external statusline tool is required**. If you already use a
+statusline renderer (ccstatusline or anything else), set `QUEUE_STATUSLINE` and
+the wrapper forwards the same stdin to it instead of rendering its own line.
 
 ### Wiring it in
 
@@ -42,12 +45,18 @@ chmod +x ~/.claude/queue/statusline-wrapper.sh
 }
 ```
 
-Already running a custom statusline? Set `QUEUE_STATUSLINE` to it (the wrapper
-forwards stdin to that command instead of `ccstatusline`):
+With nothing else configured the wrapper renders its own line. Already running a
+custom statusline? Set `QUEUE_STATUSLINE` to it and the wrapper forwards stdin to
+that command instead:
 
 ```bash
+# any renderer:
 QUEUE_STATUSLINE="my-statusline --flags" bash ~/.claude/queue/statusline-wrapper.sh
+# ccstatusline specifically:
+QUEUE_STATUSLINE="bunx -y ccstatusline@latest" bash ~/.claude/queue/statusline-wrapper.sh
 ```
+
+Set it via the `statusLine.command`'s `env`, or export it before Claude starts.
 
 Give the terminal ~10–15 s to render once, then confirm:
 
@@ -63,7 +72,7 @@ first API response of a session.
 | Var | Default | Purpose |
 |-----|---------|---------|
 | `QUEUE_STATE_FILE` | `~/.claude/queue/state.json` | Where state is read/written |
-| `QUEUE_STATUSLINE` | `bunx -y ccstatusline@latest` | The real statusline to forward to |
+| `QUEUE_STATUSLINE` | _(unset)_ | External statusline command to forward stdin to; unset renders the built-in line |
 
 ## Notes & limits
 

--- a/skills/queue/scripts/statusline-wrapper.sh
+++ b/skills/queue/scripts/statusline-wrapper.sh
@@ -43,9 +43,11 @@ EOF
 # resets_at is interpolated raw into JSON, so a non-numeric value (e.g. an
 # ISO-8601 string) would corrupt the state file — worse than no file, since both
 # consumers would then jq-fail to empty and misreport the cause. Guard it to a
-# bare integer epoch; guard used to a bare number (digits + at most one dot).
+# bare integer epoch; guard used to a well-formed JSON number. The leading- and
+# trailing-dot cases (.5, 40., .) matter: they'd be a non-numeric percentage AND
+# invalid JSON if interpolated raw, so they must reduce to null like any garbage.
 case "$resets_at" in ''|*[!0-9]*) resets_at="" ;; esac
-case "$used" in ''|*[!0-9.]*|*.*.*) used="" ;; esac
+case "$used" in ''|.*|*.|*[!0-9.]*|*.*.*) used="" ;; esac
 
 # Tap: only persist a real window (resets_at present); used falls back to null.
 if [ -n "$resets_at" ]; then
@@ -67,7 +69,10 @@ else
   fi
   [ -n "$model" ] && line="${line:+$line · }$model"
   if [ -n "$used" ]; then
-    seg="5h $(awk -v u="$used" 'BEGIN{ printf "%d", u+0 }')%"
+    # Truncate to whole percent in pure bash (no awk subprocess — this renders
+    # on every statusline refresh). `used` is guaranteed well-formed above, so
+    # stripping the fraction floors it for a non-negative percentage.
+    seg="5h ${used%%.*}%"
     [ -n "$resets_at" ] && seg="$seg (resets $(date -r "$resets_at" +%H:%M))"
     line="${line:+$line · }$seg"
   fi

--- a/skills/queue/scripts/statusline-wrapper.sh
+++ b/skills/queue/scripts/statusline-wrapper.sh
@@ -1,18 +1,23 @@
 #!/usr/bin/env bash
-# statusline-wrapper.sh — taps the 5-hour usage-window reset time into a state
-# file on its way through to your real statusline renderer.
+# statusline-wrapper.sh — taps the 5-hour usage-window data into a state file,
+# then renders the statusline.
 #
 # Claude Code pipes a JSON blob to the statusLine command on stdin. For Pro/Max
 # subscribers it includes `rate_limits.five_hour.{resets_at,used_percentage}` —
 # the moment the current 5h usage window flips and how much is consumed. That
 # data is NOT available to anything running inside a session, so we capture it
-# here. Reads stdin once, persists to the state file, then forwards the SAME
-# stdin to the real renderer (default: ccstatusline) and prints its output.
+# here from the one channel that carries it.
+#
+# Rendering: with no external statusline tool the built-in compact line is used,
+# so these skills work standalone (no ccstatusline / bun required). Set
+# QUEUE_STATUSLINE to forward stdin to any external renderer instead — e.g.
+# QUEUE_STATUSLINE="bunx -y ccstatusline@latest" for ccstatusline.
 #
 # Config (env):
 #   QUEUE_STATE_FILE   where to write state (default ~/.claude/queue/state.json)
-#   QUEUE_STATUSLINE   the real statusline command to forward to
-#                      (default: bunx -y ccstatusline@latest)
+#   QUEUE_STATUSLINE   external statusline command to forward stdin to; unset
+#                      renders the built-in line.
+# macOS/BSD `date` only (the built-in line uses `date -r <epoch>`).
 set -u
 
 STATE_FILE="${QUEUE_STATE_FILE:-$HOME/.claude/queue/state.json}"
@@ -20,23 +25,51 @@ mkdir -p "$(dirname "$STATE_FILE")"
 
 input="$(cat)"
 
-# Tap the 5h window fields; only persist when resets_at is present and a bare
-# integer epoch. Guarding here matters: resets_at is interpolated raw into the
-# JSON below, so a non-numeric value (e.g. an ISO-8601 string) would write a
-# corrupt, unparseable state file — worse than no file, since both consumers
-# would then jq-fail to empty and misreport the cause as "no resets_at".
-resets_at="$(printf '%s' "$input" | jq -r '.rate_limits.five_hour.resets_at // empty' 2>/dev/null)"
+# One jq pass pulls everything we need — the two tap fields plus the render
+# fields — joined on US (0x1f). A non-whitespace separator is deliberate: tab is
+# an IFS-whitespace char, which would collapse the leading empty fields when
+# rate_limits is absent (mis-shifting model/dir); 0x1f preserves empty fields
+# and can't occur in a model name or path.
+IFS=$'\x1f' read -r resets_at used model dir <<EOF
+$(printf '%s' "$input" | jq -r '[
+    (.rate_limits.five_hour.resets_at // ""),
+    (.rate_limits.five_hour.used_percentage // ""),
+    (.model.display_name // .model.id // ""),
+    (.workspace.current_dir // .cwd // "")
+  ] | map(tostring) | join("\u001f")' 2>/dev/null)
+EOF
+
+# Normalize the two numeric fields once, shared by the tap and the render below.
+# resets_at is interpolated raw into JSON, so a non-numeric value (e.g. an
+# ISO-8601 string) would corrupt the state file — worse than no file, since both
+# consumers would then jq-fail to empty and misreport the cause. Guard it to a
+# bare integer epoch; guard used to a bare number (digits + at most one dot).
 case "$resets_at" in ''|*[!0-9]*) resets_at="" ;; esac
+case "$used" in ''|*[!0-9.]*|*.*.*) used="" ;; esac
+
+# Tap: only persist a real window (resets_at present); used falls back to null.
 if [ -n "$resets_at" ]; then
-  # used_percentage is a float and is interpolated raw too — same corruption risk
-  # as resets_at. Keep only a bare number (digits + at most one dot); anything
-  # else (absent, or unexpected non-numeric) becomes JSON null.
-  used="$(printf '%s' "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty' 2>/dev/null)"
-  case "$used" in ''|*[!0-9.]*|*.*.*) used="null" ;; esac
-  now="$(date +%s)"
   printf '{"resets_at":%s,"used_percentage":%s,"captured_at":%s}\n' \
-    "$resets_at" "$used" "$now" > "$STATE_FILE"
+    "$resets_at" "${used:-null}" "$(date +%s)" > "$STATE_FILE"
 fi
 
-# Forward original stdin to the real statusline renderer (output unchanged).
-printf '%s' "$input" | ${QUEUE_STATUSLINE:-bunx -y ccstatusline@latest}
+# Render. Forward to an external renderer if asked; otherwise our own line.
+if [ -n "${QUEUE_STATUSLINE:-}" ]; then
+  printf '%s' "$input" | ${QUEUE_STATUSLINE}
+else
+  # Built-in compact line: "dir (branch) · model · 5h NN% (resets HH:MM)".
+  # Each segment is included only when its data is available, so free-tier
+  # users (no rate_limits) still get a clean "dir (branch) · model" line.
+  line=""
+  if [ -n "$dir" ]; then
+    branch="$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+    if [ -n "$branch" ]; then line="${dir##*/} ($branch)"; else line="${dir##*/}"; fi
+  fi
+  [ -n "$model" ] && line="${line:+$line · }$model"
+  if [ -n "$used" ]; then
+    seg="5h $(awk -v u="$used" 'BEGIN{ printf "%d", u+0 }')%"
+    [ -n "$resets_at" ] && seg="$seg (resets $(date -r "$resets_at" +%H:%M))"
+    line="${line:+$line · }$seg"
+  fi
+  printf '%s\n' "$line"
+fi

--- a/tests/queue/caliper-test_statusline_seam.sh
+++ b/tests/queue/caliper-test_statusline_seam.sh
@@ -32,12 +32,19 @@ assert() {
   else echo "FAIL: $desc"; echo "  cond: $cond"; fail=$((fail+1)); fi
 }
 
-# Pipe a statusline JSON blob through the real wrapper. QUEUE_STATUSLINE=cat
-# both avoids invoking the default ccstatusline (network) and lets us assert the
-# wrapper forwards stdin unchanged. Returns the renderer's stdout in FWD.
+# Pipe a statusline JSON blob through the real wrapper with an EXTERNAL renderer
+# (QUEUE_STATUSLINE=cat) — lets us assert the wrapper forwards stdin unchanged.
+# Returns the renderer's stdout in FWD.
 produce() {
   rm -f "$STATE"
   FWD="$(printf '%s' "$1" | env QUEUE_STATE_FILE="$STATE" QUEUE_STATUSLINE="cat" \
+    PATH="$PATH" HOME="$HOME" bash "$WRAPPER")"
+}
+# Pipe a blob through the wrapper with NO external renderer (QUEUE_STATUSLINE
+# unset) — exercises the built-in line. Returns the rendered line in OUT.
+render() {
+  rm -f "$STATE"
+  OUT="$(printf '%s' "$1" | env -u QUEUE_STATUSLINE QUEUE_STATE_FILE="$STATE" \
     PATH="$PATH" HOME="$HOME" bash "$WRAPPER")"
 }
 # Run a consumer against whatever the wrapper wrote; capture out/err/rc.
@@ -108,6 +115,28 @@ assert "compute-fire reports no-data (exit 1) not corruption" '[[ $RC -eq 1 ]]'
 # --- No rate_limits at all (free tier / pre-first-response): nothing written ---
 produce '{"model":{"id":"x"}}'
 assert "blob without rate_limits -> no state file" '[[ ! -f "$STATE" ]]'
+
+# --- Built-in render path (no external statusline tool installed) ---
+# Works standalone: the wrapper renders its own line and still taps the state.
+tmpdir="$(mktemp -d)"; trap 'rm -f "$STATE"; rm -rf "$tmpdir"' EXIT   # non-git dir
+exp_hm="$(date -r "$future" +%H:%M)"
+render "{\"rate_limits\":{\"five_hour\":{\"resets_at\":$future,\"used_percentage\":40.5}},\"model\":{\"display_name\":\"Opus 4.8\"},\"workspace\":{\"current_dir\":\"$tmpdir\"}}"
+assert "built-in: still taps state file"        '[[ -f "$STATE" ]]'
+assert "built-in: shows dir basename"           '[[ "$OUT" == *"${tmpdir##*/}"* ]]'
+assert "built-in: shows model display_name"     '[[ "$OUT" == *"Opus 4.8"* ]]'
+assert "built-in: shows 5h percentage (int)"    '[[ "$OUT" == *"5h 40%"* ]]'
+assert "built-in: shows reset wall-clock"       '[[ "$OUT" == *"resets $exp_hm"* ]]'
+assert "built-in: non-git dir -> no (branch)"   '[[ "$OUT" != *"${tmpdir##*/} ("* ]]'
+
+# A git working dir adds a (branch) segment.
+render "{\"model\":{\"id\":\"m\"},\"workspace\":{\"current_dir\":\"$REPO_ROOT\"}}"
+assert "built-in: git dir shows (branch)"        '[[ "$OUT" == *"("*")"* ]]'
+
+# Free tier (no rate_limits): clean dir/model line, no 5h segment, no state file.
+render "{\"model\":{\"display_name\":\"Sonnet\"},\"workspace\":{\"current_dir\":\"$tmpdir\"}}"
+assert "built-in free-tier: shows model"        '[[ "$OUT" == *"Sonnet"* ]]'
+assert "built-in free-tier: no 5h segment"      '[[ "$OUT" != *"5h"* ]]'
+assert "built-in free-tier: no state written"   '[[ ! -f "$STATE" ]]'
 
 echo "----"
 echo "statusline-seam: $pass passed, $fail failed"

--- a/tests/queue/caliper-test_statusline_seam.sh
+++ b/tests/queue/caliper-test_statusline_seam.sh
@@ -104,6 +104,14 @@ assert "non-numeric used_percentage -> null"             '[[ "$(jq -r .used_perc
 run "$CHECK_USAGE"
 assert "check-usage -> exit 2 on sanitized-null used_pct" '[[ $RC -eq 2 ]]'
 
+# Leading/trailing-dot forms (.5, 40., .) are invalid JSON numbers AND not a
+# usable percentage — they must reduce to null, never be interpolated raw.
+for bad in '"40."' '".5"' '"."'; do
+  produce "{\"rate_limits\":{\"five_hour\":{\"resets_at\":$future,\"used_percentage\":$bad}}}"
+  assert "malformed used_percentage $bad -> valid JSON" 'jq -e . "$STATE" >/dev/null'
+  assert "malformed used_percentage $bad -> null"       '[[ "$(jq -r .used_percentage "$STATE")" == "null" ]]'
+done
+
 # --- Producer guards a non-numeric resets_at instead of writing corrupt JSON ---
 # Without the guard, an ISO-8601 resets_at would be interpolated raw and produce
 # an unparseable file that misleads both consumers.
@@ -125,6 +133,10 @@ assert "built-in: still taps state file"        '[[ -f "$STATE" ]]'
 assert "built-in: shows dir basename"           '[[ "$OUT" == *"${tmpdir##*/}"* ]]'
 assert "built-in: shows model display_name"     '[[ "$OUT" == *"Opus 4.8"* ]]'
 assert "built-in: shows 5h percentage (int)"    '[[ "$OUT" == *"5h 40%"* ]]'
+
+# Pure-bash fraction strip floors a non-negative percent (e.g. 0.5 -> 0).
+render "{\"rate_limits\":{\"five_hour\":{\"resets_at\":$future,\"used_percentage\":0.5}},\"model\":{\"id\":\"m\"},\"workspace\":{\"current_dir\":\"$tmpdir\"}}"
+assert "built-in: sub-1 percent floors to 0"    '[[ "$OUT" == *"5h 0%"* ]]'
 assert "built-in: shows reset wall-clock"       '[[ "$OUT" == *"resets $exp_hm"* ]]'
 assert "built-in: non-git dir -> no (branch)"   '[[ "$OUT" != *"${tmpdir##*/} ("* ]]'
 


### PR DESCRIPTION
## Summary
- The statusline-wrapper used to default to forwarding stdin to `bunx -y ccstatusline@latest`, so a user with **no statusline** (and no bun/ccstatusline) got a broken statusline even though the usage tap worked. The wrapper is now self-sufficient: with `QUEUE_STATUSLINE` unset it renders its own compact line — `dir (branch) · model · 5h NN% (resets HH:MM)` — built entirely from the JSON it already reads. **No external statusline tool required.**
- ccstatusline (or any renderer) is now **opt-in** via `QUEUE_STATUSLINE`; setting it forwards stdin to that command exactly as before.
- Each render segment is conditional, so free-tier users (no `rate_limits`) get a clean `dir (branch) · model` line with the 5h segment omitted.
- Consolidated the two `jq` taps into a single pass (tap + render fields), joined on US (``) rather than tab — a non-whitespace separator is required so the leading empty fields don't collapse when `rate_limits` is absent (the seam test caught this).

## Addresses #257
The investigation concluded the statusline channel can't be removed (hooks, CLI, local files, and 429 responses all lack `rate_limits` on Claude Code v2.1.191 — confirmed by docs and direct inspection), so the recommendation is to **keep the tap and remove the friction**. This PR delivers that: the dependency on ccstatusline specifically is gone, and the wrapper works standalone. Remaining ergonomic leads (guided one-command `settings.json` setup, `seven_day` capture, a `StopFailure` rate-limit backstop) are noted in the issue for separate follow-up.

Closes #257

## Test plan
- New built-in-render seam coverage (10 assertions): Pro/Max line, git `(branch)` segment, non-git dir, free-tier degradation, and forward-path-unchanged.
- Full macOS suite: seam **34**, compute-fire **20**, check-usage **16** — all pass.
- These skills remain macOS-only and excluded from the Linux CI job (they SKIP on GNU `date`); CI-relevant hook/validate-plan suites run clean locally.
- Bumped `claude-caliper` 1.50.0→1.51.0 and `claude-caliper-tooling` 1.49.0→1.50.0.

Co-Authored-By: Claude <noreply@anthropic.com>