### PR TITLE
fix(codebase-review): direct inline implementation + haiku Explore readers + mailbox/idle fixes (#263)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.52.0",
+      "version": "1.52.1",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -59,7 +59,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit, test audit, skill evaluation, and usage-window scheduling (queue / usage-guard)",
-      "version": "1.51.0",
+      "version": "1.51.1",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/skills/codebase-review/README.md
+++ b/skills/codebase-review/README.md
@@ -46,7 +46,7 @@ Phase 2: Parallel scope reviews (one claude-caliper:codebase-auditor subagent pe
 Phase 3: Cross-scope reconciliation (one claude-caliper:codebase-auditor subagent, sees all findings)
          |
          v
-Phase 4: Aggregate + route (write report, create issues, or hand off to draft-plan)
+Phase 4: Aggregate + route (write report; inline fixes implemented directly, complex fixes → issues or draft-plan)
 ```
 
 ### Team mode flow
@@ -58,7 +58,7 @@ Mode detection → Init (artifact dir, team name) → TeamCreate
 Phase 1: 3 parallel reviewers (full repo each) → write reviewer_N.md → idle
          |
          v
-Phase 2: Lead DMs phase2_start → each reviewer reads 2 peer files,
+Phase 2: Lead DMs prose Phase 2 start → each reviewer reads 2 peer files,
          re-verifies, disputes peer-to-peer, writes crosscheck_N.md → idle
          |
          v
@@ -89,10 +89,10 @@ Merges all findings, deduplicates, and ranks by severity. Writes a report to `do
 
 Routes by **fix complexity** (not severity):
 
-- **Inline fixes** — automatically invokes `draft-plan` on the grouped findings, then `plan-review`, then proceeds to execution. No user prompt.
-- **Complex fixes** — `AskUserQuestion`: create GitHub issues (one per group) or write plans now. User chooses.
+- **Inline fixes** (1–5 line changes, no design decision) — implemented directly in a worktree from the findings table (which already carries `file:line` + fix direction, cross-verified in Phase 2), then run through the normal review gates (`/code-review`, tests). No `draft-plan`/`plan-review` — that would re-derive context the findings table already holds. No user prompt.
+- **Complex fixes** (multi-file refactors or fixes needing a design decision) — `AskUserQuestion`: create GitHub issues (one per group) or write plans now via `draft-plan`. User chooses.
 
-A Critical one-liner goes inline; a Medium refactoring across 10 files gets an issue or plan.
+A Critical one-liner is implemented inline; a Medium refactoring across 10 files gets an issue or plan.
 
 ## Review categories
 

--- a/skills/codebase-review/SKILL.md
+++ b/skills/codebase-review/SKILL.md
@@ -123,7 +123,7 @@ A medium repo (~100 files) on Opus typically completes in 5-15 minutes; consider
 
 When all 3 are idle, check each artifact file:
 
-- Failure signal A: reviewer is idle but `$ARTIFACT_DIR/reviewer_N.md` does not exist.
+- Failure signal A: reviewer is idle but `$ARTIFACT_DIR/reviewer_N.md` does not exist. A reviewer that fanned out to `Explore` subagents can look idle while its file is still pending, so idle-with-no-file is ambiguous. **Send one prose nudge DM** ("you appear idle but reviewer_N.md isn't written — finish and write it") and wait for it to go idle again. Only if the file is still absent after the nudge is it a real Phase 1 failure.
 - Failure signal B: file exists but its first non-blank line begins with `ERROR:`.
 - A literal `No findings.` file is NOT a failure — it is a valid empty result per the agent's quality bar.
 
@@ -135,7 +135,7 @@ Apply the degraded-run policy:
 
 ### Phase 2 trigger
 
-For each surviving reviewer N, send: `SendMessage({to: "cbr-rev-N", message: {type: "phase2_start", peer_files: [<absolute path of peer file 1>, <absolute path of peer file 2>]}})`. The peer files are the OTHER two surviving reviewers' `reviewer_M.md` paths. Example for reviewer 2 with all 3 alive: `peer_files: ["$ARTIFACT_DIR/reviewer_1.md", "$ARTIFACT_DIR/reviewer_3.md"]`.
+For each surviving reviewer N, send a **prose** message naming the OTHER two survivors' `reviewer_M.md` absolute paths as its peer files, e.g. `SendMessage({to: "cbr-rev-2", message: "Start Phase 2. Peer files: $ARTIFACT_DIR/reviewer_1.md and $ARTIFACT_DIR/reviewer_3.md"})`. Must be prose, not a structured object — the mailbox validator accepts only the shutdown/plan-approval protocol objects, and a bare JSON string is auto-parsed into an object and rejected too.
 
 ### Wait for Phase 2 completion
 
@@ -199,37 +199,18 @@ Send `SendMessage({to: "cbr-rev-N", message: {type: "shutdown_request"}})` to ea
 3. Group findings by overlapping file sets — findings that touch the same files belong in the same plan or issue
 4. Route by fix complexity:
 
-**Inline fixes** (automatically, no user prompt):
-- Invoke `draft-plan` with the grouped inline findings as requirements
-- Invoke `plan-review` on the resulting plan
-- Proceed to execution
+**Inline fixes** (1–5 line changes, no design decision — implement directly, no user prompt): the findings table *is* the plan — each row has an exact `file:line`, the problem, and a fix direction, cross-verified in Phase 2, already in your context. Skip `draft-plan`/`plan-review` (they'd re-derive that context at token cost); implement the grouped findings in a worktree and run the diff through the normal gates (`/code-review`, tests). Promote a finding to the complex path if opening the code reveals a design decision.
 
-**Complex fixes** (AskUserQuestion — pick one):
+**Complex fixes** (multi-file refactors, or any fix needing a design decision — AskUserQuestion, pick one):
 - **Create GitHub issues** — one issue per logical group → `gh issue create`
-- **Write plans now** — invoke `draft-plan` per group, then `plan-review`
+- **Write plans now** — `draft-plan` per group, then `plan-review`. A codebase-review-initiated plan has no design-review, so `draft-plan`'s entry gate fails unless you first write a `reviews.json` array with a design-review skip record: `[{"type":"design-review","scope":"design","verdict":"skip","reason":"codebase-review-initiated"}]` (the gate selects on both `type` and `scope`; a `skip` verdict needs a non-empty `reason`).
 
-Routing is based on fix COMPLEXITY, not severity. A Critical one-liner goes inline; a Medium refactoring across 10 files gets an issue or plan.
+Route by fix COMPLEXITY, not severity: a Critical one-liner goes inline; a Medium 10-file refactor gets an issue/plan.
 
 ## Report Structure
 
-```text
-# Codebase Review — YYYY-MM-DD
-Scope: [path] | Review units: [list]
-Summary: X findings (N Critical, N High, N Medium, N Low) | Y deferred → GH issues | Z inline → implementation
-
-## Findings by Severity
-| # | Category | Severity | File(s) | Description | Fix Complexity |
-
-## Deferred Work
-| # | Finding | Rationale | GitHub Issue # |
-```
+Single mode uses the team-mode master-doc schema above, minus the `Tier` column and `Lead Notes` section, plus `N Low` in the summary counts.
 
 ## Categories
 
-- **DRY** — duplicated logic, repeated constants
-- **YAGNI** — unused code, dead paths, speculative features
-- **Simplicity & Efficiency** — over-abstraction, unnecessary indirection
-- **Refactoring Opportunities** — SRP violations, God objects, deep nesting
-- **Consistency** — naming drift, style divergence
-
-Full category definitions, severity rubric, and output Finding template live in the `claude-caliper:codebase-auditor` agent's system prompt — that agent is dispatched in both modes.
+The five categories (DRY, YAGNI, Simplicity & Efficiency, Refactoring Opportunities, Consistency), their full definitions, the severity rubric, and the output Finding template live in the `claude-caliper:codebase-auditor` agent's system prompt — that agent is dispatched in both modes.

--- a/skills/codebase-review/agents/team-reviewer.md
+++ b/skills/codebase-review/agents/team-reviewer.md
@@ -13,20 +13,20 @@ Each of the 3 named teammates (`cbr-rev-1`, `cbr-rev-2`, `cbr-rev-3`) reads this
 
 ## Phase 1 — Independent Full-Codebase Review
 
-1. Read the full scope at `SCOPE_PATH` top-down. Read every file.
+1. Read the full scope at `SCOPE_PATH` top-down. For a scope small enough to hold in your own context, read every file directly. For a larger scope, fan out context-gathering to **`Explore` subagents on the `haiku` model** (`Agent({subagent_type: "Explore", model: "haiku", ...})`) — they read excerpts and return conclusions, which is what you need to locate issues. **Do NOT dispatch inherited/default-model general-purpose subagents for exploration:** they in turn spawn their own subagents and token usage spirals recursively. The independent judgment that makes team mode valuable is *yours* — what you flag from the gathered context — not the reading itself, so cheap haiku readers cost you nothing in review quality.
 2. Apply the 5 categories and severity definitions from your system prompt.
 3. Mark **Critical / High / Medium only** — team mode drops Low findings (override of the agent's default severity set).
 4. Use the Finding output format from your system prompt for each finding. Cite `file:line` for every one.
 5. Write your findings to `$ARTIFACT_DIR/reviewer_$REVIEWER_NUMBER.md`. If you have nothing that meets the bar, write the literal line `No findings.` as the entire file contents (the agent's quality bar — do not invent findings).
-6. Go idle. **Do NOT send a completion DM.** File existence plus your idle notification is the lead's signal that Phase 1 is done for you.
+6. **Only after `reviewer_$REVIEWER_NUMBER.md` is written**, go idle. If you dispatched `Explore` subagents, wait for them to return and finish your findings first — do not go idle while children are still running. **Do NOT send a completion DM.** File existence plus your idle notification is the lead's signal that Phase 1 is done for you; going idle with children still working makes that signal ambiguous.
 
 **If you cannot proceed** (e.g., `SCOPE_PATH` inaccessible, `ARTIFACT_DIR` not writable), write `ERROR: <one-line reason>` as the first non-blank line of `$ARTIFACT_DIR/reviewer_$REVIEWER_NUMBER.md` and go idle. The lead treats this as a Phase 1 failure per the degraded-run rules.
 
 ## Phase 2 — Peer Cross-Verification
 
-You wake from idle when the lead DMs you `{type: "phase2_start", peer_files: ["<absolute path>", "<absolute path>"]}` — the two paths are the other reviewers' Phase 1 artifacts. Follow this strict ordering to avoid races:
+You wake from idle when the lead DMs you a **prose** Phase 2 start message naming the two peer files — the absolute paths of the other reviewers' Phase 1 artifacts. (The message is prose, not a structured object: the mailbox validator only accepts the shutdown/plan-approval protocol objects, and a bare JSON string gets auto-parsed into an object and rejected too — so the lead sends this instruction as plain text.) Follow this strict ordering to avoid races:
 
-1. **Read both peer files** at the absolute paths in `peer_files`.
+1. **Read both peer files** at the two absolute paths from the Phase 2 start message.
 2. **Re-verify each peer finding against the code.** Open the cited files and check whether the finding holds.
 3. **Send disputes** (if any) directly to the originating peer via peer-to-peer DM. The originator is identified by their reviewer number, which appears in the filename (e.g., `reviewer_1.md` was written by `cbr-rev-1`):
     - DM target: `cbr-rev-N` (where N is the originator's reviewer number)
@@ -65,13 +65,13 @@ Escalations are rare. Use them only when peer-to-peer dispute cannot resolve.
 
 ## Mailbox Protocol
 
-Message types you receive and may send during Phase 2 (the window between `phase2_start` arrival and your Phase 2 idle):
+Message types you receive and may send during Phase 2 (the window between the Phase 2 start message arriving and your Phase 2 idle):
 
 | Direction | Type | Payload | When |
 |---|---|---|---|
-| lead → you | `phase2_start` | `{peer_files: ["<absolute path>", "<absolute path>"]}` | Phase 2 start signal |
+| lead → you | Phase 2 start | **prose** naming the two peer-file absolute paths | Phase 2 start signal |
 | peer → you | `dispute` | `{finding_id, reasoning}` | Sent within the dispute window only |
 | you → peer | `dispute` | `{finding_id, reasoning}` | Sent within the dispute window only |
 | lead → you | `shutdown_request` | `{}` | After lead synthesis; respond by going idle |
 
-Do not invent message types. Anything else inbound: ignore.
+The Phase 2 start signal arrives as prose (see Phase 2 intro for why). The `dispute` and `shutdown_request` message types are structured objects. Do not invent message types. Anything else inbound: ignore.


### PR DESCRIPTION
## Summary
Addresses GitHub issue #263 (feedback from a real team-mode `/codebase-review` run).

- **Phase 4 inline routing (#1):** inline fixes (1–5 line, no design decision) now implement directly from the cross-verified findings table + normal review gates (`/code-review`, tests) instead of routing through `draft-plan` → `plan-review` — the findings table already *is* the plan, so re-deriving it cost tokens for no new information. Complex/design-decision fixes still use `draft-plan`, with the `reviews.json` design-review skip-record now documented (verified against `validate-plan`: gate selects on both `type` and `scope:"design"`, and a `skip` verdict needs a non-empty `reason`).
- **Reviewer token spiral (#2):** team-mode reviewers now fan out context-gathering to `Explore` subagents on the **haiku** model, never inherited/default-model general subagents (which recursively spawn their own subagents and spiral token usage). Independent *judgment* — the thing that makes team mode valuable — stays with each reviewer; the reading is cheap. Team/mailbox substrate unchanged.
- **Misc:** Phase 2 start signal sent as **prose** (the mailbox validator rejects structured objects and auto-parses bare JSON strings into rejected objects); reviewers stay non-idle until their file is written and the lead nudges once before declaring an idle-with-no-file failure (disambiguates idle-means-done when reviewers use background subagents).
- Trimmed redundant Categories bullets + single-mode Report Structure block to keep SKILL.md at the 2000-word cap. Bumped `claude-caliper` (1.52.1) and `claude-caliper-tooling` (1.51.1).

## Test plan
- `tests/codebase-review/mode-detection.sh` — 7 passed, 0 failed
- `jq empty .claude-plugin/marketplace.json` — valid
- SKILL.md word count = 2000 (within hard cap)
- No stale `phase2_start`/`peer_files` references remain

Closes #263

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified review workflow guidance for team and single-mode processes.
  * Updated instructions around phase transitions, reviewer coordination, and message formats.

* **Chores**
  * Bumped two plugin versions in the marketplace manifest to newer patch releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->