### PR TITLE
fix(usage-guard,queue): guard against cross-session stale-blob poisoning of state.json (#265)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "1.52.1",
+      "version": "1.52.2",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -59,7 +59,7 @@
     {
       "name": "claude-caliper-tooling",
       "description": "Standalone tools: codebase audit, test audit, skill evaluation, and usage-window scheduling (queue / usage-guard)",
-      "version": "1.51.1",
+      "version": "1.51.2",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",

--- a/skills/queue/scripts/compute-fire.sh
+++ b/skills/queue/scripts/compute-fire.sh
@@ -29,6 +29,8 @@ set -u
 
 STATE_FILE="${QUEUE_STATE_FILE:-$HOME/.claude/queue/state.json}"
 STALE_SEC=90            # statusline refreshes ~every 10s; >90s ⇒ likely not rendering
+PAST_GRACE_SEC=120      # a resets_at slightly past is a just-reset window; well past
+                        # is a stale cross-session blob (see check-usage.sh)
 now="$(date +%s)"
 mode="reset"
 epoch=""
@@ -78,6 +80,14 @@ if [ "$mode" = "reset" ]; then
       echo "ERROR: state file has no valid resets_at for the $WINDOW window (rate_limits is Pro/Max-only, and appears after the first API response; each window may be independently absent)." >&2
       exit 2 ;;
   esac
+  # A resets_at well in the past (beyond PAST_GRACE_SEC) isn't a just-reset window
+  # — it's a stale cross-session blob. Distinguish it from a legitimately-just-reset
+  # window (handled below with "run now") so the caller retries for fresh data
+  # instead of being told a dead window's stamp means it can act immediately.
+  if [ "$resets_at" -lt $(( now - PAST_GRACE_SEC )) ]; then
+    echo "ERROR: the $WINDOW window's resets_at ($(date -r "$resets_at" '+%Y-%m-%d %H:%M:%S %Z')) is far in the past — the state file holds a stale cross-session blob, not a fresh reset time. Focus this terminal ~10-15s to re-render, then retry." >&2
+    exit 2
+  fi
   # Staleness from captured_at; default 0 so a missing/non-numeric value reads as
   # very stale (not falsely fresh).
   captured="$(jq -r '.captured_at // 0' "$STATE_FILE" 2>/dev/null)"

--- a/skills/queue/scripts/statusline-wrapper.sh
+++ b/skills/queue/scripts/statusline-wrapper.sh
@@ -61,18 +61,37 @@ case "$seven_used" in ''|.*|*.|*[!0-9.]*|*.*.*) seven_used="" ;; esac
 # .used_percentage unchanged); seven_day is always written as a sub-object so the
 # shape is stable, with null fields when that window is absent. A missing window's
 # resets_at is null, which the consumers treat as "data unavailable".
-#
-# Write via a temp file + atomic mv: this renders every ~10s and the consumers
-# (check-usage.sh / compute-fire.sh) read the file concurrently, so a direct `>`
-# redirect could expose a half-written file and make a consumer misreport
-# "data unavailable". mv on the same filesystem is atomic.
 if [ -n "$resets_at" ] || [ -n "$seven_resets" ]; then
-  tmp="$STATE_FILE.tmp.$$"
-  if printf '{"resets_at":%s,"used_percentage":%s,"captured_at":%s,"seven_day":{"resets_at":%s,"used_percentage":%s}}\n' \
-      "${resets_at:-null}" "${used:-null}" "$(date +%s)" "${seven_resets:-null}" "${seven_used:-null}" > "$tmp" 2>/dev/null; then
-    mv "$tmp" "$STATE_FILE"
-  else
-    rm -f "$tmp"
+  # Cross-session regression guard. state.json is shared by EVERY Claude session on
+  # the machine, and captured_at is stamped at write time — so an idle session still
+  # holding a STALE rate_limits blob (a window that reset long ago) would otherwise
+  # overwrite an active session's fresh data and stamp it fresh, poisoning every
+  # consumer with no staleness signal to catch it. A window's resets_at only ever
+  # moves forward, so an incoming value OLDER than what's on disk means this render
+  # is the stale one: skip the write. Equal/newer still writes, so used_percentage
+  # keeps updating within a window and a genuine reset (resets_at jumps forward) lands.
+  skip=""
+  if [ -f "$STATE_FILE" ]; then
+    cur_resets="$(jq -r '.resets_at // empty' "$STATE_FILE" 2>/dev/null)"
+    cur_seven="$(jq -r '.seven_day.resets_at // empty' "$STATE_FILE" 2>/dev/null)"
+    case "$cur_resets" in ''|*[!0-9]*) cur_resets="" ;; esac
+    case "$cur_seven" in ''|*[!0-9]*) cur_seven="" ;; esac
+    { [ -n "$resets_at" ] && [ -n "$cur_resets" ] && [ "$resets_at" -lt "$cur_resets" ]; } && skip="yes"
+    { [ -n "$seven_resets" ] && [ -n "$cur_seven" ] && [ "$seven_resets" -lt "$cur_seven" ]; } && skip="yes"
+  fi
+
+  # Write via a temp file + atomic mv: this renders every ~10s and the consumers
+  # (check-usage.sh / compute-fire.sh) read the file concurrently, so a direct `>`
+  # redirect could expose a half-written file and make a consumer misreport
+  # "data unavailable". mv on the same filesystem is atomic.
+  if [ -z "$skip" ]; then
+    tmp="$STATE_FILE.tmp.$$"
+    if printf '{"resets_at":%s,"used_percentage":%s,"captured_at":%s,"seven_day":{"resets_at":%s,"used_percentage":%s}}\n' \
+        "${resets_at:-null}" "${used:-null}" "$(date +%s)" "${seven_resets:-null}" "${seven_used:-null}" > "$tmp" 2>/dev/null; then
+      mv "$tmp" "$STATE_FILE"
+    else
+      rm -f "$tmp"
+    fi
   fi
 fi
 

--- a/skills/usage-guard/SKILL.md
+++ b/skills/usage-guard/SKILL.md
@@ -34,7 +34,10 @@ kept fresh by the queue skill's statusline wrapper. It prints `WINDOW=`, `USED_P
   loop is otherwise identical; just thread the same `--window` value through every
   check this run so cadence and the threshold branch track one window.
 - This depends on the **queue skill's statusline wrapper** being wired in. If
-  check-usage exits 1/2, relay its stderr and stop — usage can't be read.
+  check-usage exits 1/2, relay its stderr and stop — usage can't be read. One
+  exception: exit 2 with a *past `resets_at`* stderr is a transient cross-session
+  glitch (a stale blob from another session, overwritten within ~10s). Re-run once
+  after ~5s before stopping; only stop if it repeats.
 - `STALE=yes` (the same >90s cutoff `compute-fire.sh` uses) means the statusline
   hasn't rendered recently — terminal idle/unfocused — so `USED_PCT` lags reality.
   Note it; the number may be behind.

--- a/skills/usage-guard/scripts/check-usage.sh
+++ b/skills/usage-guard/scripts/check-usage.sh
@@ -12,8 +12,9 @@
 #   0  = UNDER threshold (keep going)
 #   10 = AT/OVER threshold (stop / queue)
 #   1  = no state file (wrapper not wired in, or no render yet)
-#   2  = no used_percentage for the chosen window (Pro/Max only, after first API
-#        response — and each window may be independently absent)
+#   2  = data unavailable for the chosen window: no used_percentage (Pro/Max only,
+#        after first API response — each window may be independently absent), OR a
+#        resets_at already in the past (a self-contradictory reading — see below)
 #   64 = usage error (bad flag / unknown --window value)
 #
 # CAPTURED_AGE_SEC is the staleness signal: large ⇒ the statusline isn't
@@ -26,6 +27,8 @@ set -u
 
 STATE_FILE="${QUEUE_STATE_FILE:-$HOME/.claude/queue/state.json}"
 STALE_SEC=90            # statusline refreshes ~every 10s; >90s ⇒ likely not rendering
+PAST_GRACE_SEC=120      # allow a window's resets_at to sit slightly in the past
+                        # (clock skew + the ~90s reset lag) before calling it stale
 
 # Parse flags. --window selects the rolling window; the lone positional is the
 # threshold (kept positional for backward compatibility with existing callers).
@@ -80,6 +83,19 @@ case "$captured" in ''|*[!0-9]*) captured=0 ;; esac
 
 now="$(date +%s)"
 age=$(( now - captured ))
+
+# A reading whose window has ALREADY reset is self-contradictory: resets_at is the
+# payload's own timestamp, so if it's in the past the used_percentage describes a
+# window that no longer exists. This is the cross-session poisoning signature — the
+# state file is shared by every session, and an idle session holding a stale
+# rate_limits blob can overwrite it with a long-reset window, stamped captured_at=now
+# so STALE can't catch it (the write IS recent; only the payload is old). Treat a
+# past resets_at (beyond PAST_GRACE_SEC) as data-unavailable → exit 2, so callers
+# fall into the retry/relay path instead of trusting a false OVER on a dead window.
+if [ -n "$resets_at" ] && [ "$resets_at" -lt $(( now - PAST_GRACE_SEC )) ]; then
+  echo "ERROR: the $WINDOW window's resets_at ($(date -r "$resets_at" '+%Y-%m-%d %H:%M %Z')) is in the past — its used_percentage describes an already-reset window (likely a stale cross-session blob). Retry in ~5s for a fresh render." >&2
+  exit 2
+fi
 
 # Display value rounded to 1 decimal (statusline can carry float noise like
 # 28.000000000000004); keep raw $used for the threshold compare.

--- a/tests/queue/caliper-test_compute_fire.sh
+++ b/tests/queue/caliper-test_compute_fire.sh
@@ -74,6 +74,23 @@ rm -f "$STATE"
 run
 assert "no state file -> exit 1"     '[[ $RC -eq 1 ]]'
 
+# --- reset mode: far-past resets_at is a stale cross-session blob, not a fresh
+# reset (#265). Distinguished from a legitimately-just-reset window by the grace
+# window: far past -> exit 2 (retry for fresh data); just past -> exit 3 (run now).
+past=$(( now - 3*7*86400 ))                                 # ~3 weeks ago
+mkstate "{\"resets_at\":$past,\"used_percentage\":100,\"captured_at\":$now}"
+run
+assert "far-past resets_at -> exit 2 (stale blob)" '[[ $RC -eq 2 ]]'
+assert "far-past message mentions stale/cross-session" '[[ "$STDERR" == *"stale cross-session"* ]]'
+# A window reset only seconds ago is within the grace band — a real just-reset
+# window, not a stale blob. It must NOT be flagged as data-unavailable (exit 2);
+# it either schedules a fire (exit 0) or, if reset+90 already elapsed, says run-now
+# (exit 3) — both mean "the reading is trusted".
+justpast=$(( now - 30 ))                                    # within PAST_GRACE_SEC
+mkstate "{\"resets_at\":$justpast,\"used_percentage\":40,\"captured_at\":$now}"
+run
+assert "just-reset window is trusted (exit != 2)" '[[ $RC -ne 2 ]]'
+
 # --- epoch mode ---
 tgt=$(( (now/3600 + 3)*3600 + 12*60 ))                      # future :12 local
 run --epoch "$tgt"

--- a/tests/queue/caliper-test_statusline_seam.sh
+++ b/tests/queue/caliper-test_statusline_seam.sh
@@ -168,6 +168,31 @@ assert "compute-fire default -> exit 2 (no 5h)"   '[[ $RC -eq 2 ]]'
 run "$COMPUTE_FIRE" --window 7d
 assert "compute-fire --window 7d exit 0 (has 7d)" '[[ $RC -eq 0 ]]'
 
+# --- Cross-session regression guard: a stale render can't poison a fresh one (#265) ---
+# state.json is shared by every session; an idle session holding a stale rate_limits
+# blob (a long-reset window) must NOT overwrite an active session's fresh data — the
+# wrapper stamps captured_at at write time, so nothing downstream could catch it.
+# feed pipes a blob WITHOUT clearing $STATE first, so the guard sees prior contents.
+feed() { printf '%s' "$1" | env QUEUE_STATE_FILE="$STATE" QUEUE_STATUSLINE="cat" \
+  PATH="$PATH" HOME="$HOME" bash "$WRAPPER" >/dev/null; }
+older=$(( future - 3*7*86400 ))                              # ~3 weeks before $future
+produce "{\"rate_limits\":{\"five_hour\":{\"resets_at\":$future,\"used_percentage\":42.0}}}"
+feed    "{\"rate_limits\":{\"five_hour\":{\"resets_at\":$older,\"used_percentage\":100.0}}}"
+assert "stale 5h render is skipped (resets_at unchanged)" "jq -e '.resets_at == $future' \"\$STATE\" >/dev/null"
+assert "stale 5h render is skipped (used_pct unchanged)"  'jq -e ".used_percentage == 42" "$STATE" >/dev/null'
+# equal resets_at with a new used_percentage still writes (in-window progress).
+feed    "{\"rate_limits\":{\"five_hour\":{\"resets_at\":$future,\"used_percentage\":58.0}}}"
+assert "same-window used_pct update is written"           'jq -e ".used_percentage == 58" "$STATE" >/dev/null'
+# a genuine reset (resets_at moves forward) is written.
+newer5=$(( future + 5*3600 ))
+feed    "{\"rate_limits\":{\"five_hour\":{\"resets_at\":$newer5,\"used_percentage\":2.0}}}"
+assert "genuine reset (newer resets_at) is written"       "jq -e '.resets_at == $newer5' \"\$STATE\" >/dev/null"
+# the 7d window is guarded independently.
+produce "{\"rate_limits\":{\"seven_day\":{\"resets_at\":$future7,\"used_percentage\":30.0}}}"
+older7=$(( future7 - 14*86400 ))
+feed    "{\"rate_limits\":{\"seven_day\":{\"resets_at\":$older7,\"used_percentage\":99.0}}}"
+assert "stale 7d render is skipped (resets_at unchanged)"  "jq -e '.seven_day.resets_at == $future7' \"\$STATE\" >/dev/null"
+
 # --- Built-in render path (no external statusline tool installed) ---
 # Works standalone: the wrapper renders its own line and still taps the state.
 tmpdir="$(mktemp -d)"; trap 'rm -f "$STATE"; rm -rf "$tmpdir"' EXIT   # non-git dir

--- a/tests/usage-guard/caliper-test_check_usage.sh
+++ b/tests/usage-guard/caliper-test_check_usage.sh
@@ -115,6 +115,25 @@ mkstate "{\"resets_at\":$reset,\"used_percentage\":42.7,\"captured_at\":$now,\"s
 run --window 7d
 assert "--window 7d, null 7d used_pct -> exit 2" '[[ $RC -eq 2 ]]'
 
+# --- past resets_at is self-contradictory: exit 2, never a trusted verdict (#265) ---
+# The state file is shared across sessions; an idle session with a stale rate_limits
+# blob can overwrite it with a long-reset window, stamped captured_at=now (STALE=no).
+# A resets_at in the past means used_percentage describes a dead window — fail to
+# data-unavailable so callers retry instead of acting on a false OVER.
+past=$(( now - 3*7*86400 ))            # ~3 weeks ago (the observed poison payload)
+mkstate "{\"resets_at\":$past,\"used_percentage\":100.0,\"captured_at\":$now}"
+run
+assert "past 5h resets_at -> exit 2 (not false OVER)" '[[ $RC -eq 2 ]]'
+mkstate "{\"resets_at\":$reset,\"used_percentage\":42.7,\"captured_at\":$now,\"seven_day\":{\"resets_at\":$past,\"used_percentage\":100.0}}"
+run --window 7d
+assert "past 7d resets_at -> exit 2"      '[[ $RC -eq 2 ]]'
+# A resets_at just barely in the past (within the grace window) is a just-reset
+# window, not poison — still trusted.
+justpast=$(( now - 30 ))
+mkstate "{\"resets_at\":$justpast,\"used_percentage\":42.7,\"captured_at\":$now}"
+run
+assert "just-reset (within grace) still trusted -> exit 0" '[[ $RC -eq 0 ]]'
+
 # bad --window value -> exit 64 (usage error)
 mkstate "{\"resets_at\":$reset,\"used_percentage\":42.7,\"captured_at\":$now}"
 run --window weekly


### PR DESCRIPTION
Fixes #265.

## Problem

`~/.claude/queue/state.json` is shared by every Claude session on the machine. An idle session still holding a stale `rate_limits` blob (a window that reset weeks ago, pinned at 100%) re-renders and overwrites the file — and the wrapper stamps `captured_at` at write time, so the staleness signal can't catch it (the write *is* recent; only the payload is old). A consumer then reads a self-contradictory verdict — `USED_PCT=100`, `STALE=no`, `resets_at` ~3 weeks in the past — producing a false `OVER` on a window that actually has headroom. The active session's next render self-heals it ~10s later, which is why a short retry always fixes it.

## Fix — defense in both layers

- **`statusline-wrapper.sh` (stops poisoning at the source):** before the atomic `mv`, read the recorded `resets_at` per window and skip the write when the incoming `resets_at` is *older* than what's on disk. A window's `resets_at` only ever moves forward, so an older incoming value means this render is the stale one. Equal/newer still writes, so `used_percentage` keeps updating within a window and a genuine reset (resets_at jumps forward) still lands.
- **`check-usage.sh` + `compute-fire.sh` (cheap backstop):** a reading whose `resets_at` is in the past (beyond a 120s grace for clock skew + the ~90s reset lag) describes an already-reset window. Treat it as data-unavailable (`exit 2`) so callers fall into the retry/relay path instead of trusting a false verdict. `compute-fire` distinguishes this from a legitimately-just-reset window (which still says "run now" via `exit 3`).

## Docs & versioning

- `usage-guard/SKILL.md`: `exit 2` with a past-`resets_at` stderr is transient — re-run once after ~5s before stopping.
- Bumped `claude-caliper` (1.52.1 → 1.52.2) and `claude-caliper-tooling` (1.51.1 → 1.51.2), the two bundles containing the queue + usage-guard skills.

## Tests

Added coverage to all three suites: the producer→consumer seam (stale-skip, equal-write, genuine-reset-write, independent 7d guarding) and the consumer unit tests (far-past → `exit 2`, just-reset → trusted, 7d-past → `exit 2`). These are macOS-gated on BSD `date -r` (matching the existing convention) and skip cleanly on Linux CI; the platform-independent guard logic was verified manually on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bUfi9Ahr9BKj5DC5qkP5v

---
_Generated by [Claude Code](https://claude.ai/code/session_018bUfi9Ahr9BKj5DC5qkP5v)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stale usage/status data so older saved timestamps no longer overwrite newer session information.
  * Added safeguards to detect expired reset times and stop using conflicting data, reducing incorrect usage readings and reset behavior.

* **Documentation**
  * Clarified guidance for retrying usage checks when a temporary stale-data condition is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->