### PR TITLE
feat(handoff): delegate scoped work to a sibling session in a new iTerm2 pane

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-caliper",
       "description": "claude-caliper bundle",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -31,7 +31,8 @@
         "./skills/skill-eval",
         "./skills/caliper-settings",
         "./skills/queue",
-        "./skills/usage-guard"
+        "./skills/usage-guard",
+        "./skills/handoff"
       ]
     },
     {
@@ -60,8 +61,8 @@
     },
     {
       "name": "claude-caliper-tooling",
-      "description": "Standalone tools: codebase audit, test audit, skill evaluation, and usage-window scheduling (queue / usage-guard)",
-      "version": "1.52.0",
+      "description": "Standalone tools: codebase audit, test audit, skill evaluation, usage-window scheduling (queue / usage-guard), and session handoff",
+      "version": "1.53.0",
       "source": "./",
       "author": {
         "name": "Nikhil Sitaram",
@@ -73,7 +74,8 @@
         "./skills/test-audit",
         "./skills/skill-eval",
         "./skills/queue",
-        "./skills/usage-guard"
+        "./skills/usage-guard",
+        "./skills/handoff"
       ]
     }
   ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
           bash tests/hooks/caliper-test_safe_commands.sh
           bash tests/hooks/caliper-test_permission_request.sh
 
+      - name: Handoff tests
+        run: bash tests/handoff/caliper-test_spawn_pane.sh
+
       - name: Validate-plan tests
         run: |
           bash tests/validate-plan/caliper-test_schema.sh

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Claude Code plugin that turns your goal into a PR with as little friction as p
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Version](https://img.shields.io/badge/version-1.53.0-blue)](https://github.com/nikhilsitaram/claude-caliper/releases)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-6E40C9?logo=anthropic&logoColor=white)](https://claude.ai/code)
-[![Skills](https://img.shields.io/badge/16%20skills-included-2ea44f)](skills/)
+[![Skills](https://img.shields.io/badge/17%20skills-included-2ea44f)](skills/)
 
 </div>
 
@@ -25,7 +25,7 @@ Many claude workflows are either improperly context engineered, overly complicat
 
 Install claude-caliper. Describe what you want to build. Walk away.
 
-The plugin installs 16 skills that fire automatically at the right moment, enforcing a full development workflow: **design before code, test before merge.** The design skill sizes the work first and routes it — small and medium changes take an inline fast path, large ones fan out through a validated plan. You make three decisions — approve the design, review the PR, and confirm the merge — and everything between runs as a chain of fresh subagents with zero manual handoffs.
+The plugin installs 17 skills that fire automatically at the right moment, enforcing a full development workflow: **design before code, test before merge.** The design skill sizes the work first and routes it — small and medium changes take an inline fast path, large ones fan out through a validated plan. You make three decisions — approve the design, review the PR, and confirm the merge — and everything between runs as a chain of fresh subagents with zero manual handoffs.
 
 ---
 
@@ -130,9 +130,9 @@ Install only what you need:
 
 | Package | What you get | Install command |
 |---------|-------------|-----------------|
-| **claude-caliper** | All 16 skills | `/plugin install claude-caliper@claude-caliper` |
+| **claude-caliper** | All 17 skills | `/plugin install claude-caliper@claude-caliper` |
 | **claude-caliper-workflow** | Design-to-merge pipeline (11 skills) | `/plugin install claude-caliper-workflow@claude-caliper` |
-| **claude-caliper-tooling** | Codebase review + test audit + skill eval + queue + usage-guard (5 skills) | `/plugin install claude-caliper-tooling@claude-caliper` |
+| **claude-caliper-tooling** | Codebase review + test audit + skill eval + queue + usage-guard + session handoff (6 skills) | `/plugin install claude-caliper-tooling@claude-caliper` |
 
 ### Updating
 
@@ -175,6 +175,14 @@ Defer or pace work around Claude's 5-hour usage window. **macOS-only**, and rese
 |-------|---------|-------------|
 | [queue](skills/queue/) | `/queue [<when>] <commands>` | Schedule commands to fire later in the same session via a one-shot cron — by default ~90s after the 5h window resets (fresh quota), or at a time/duration you name |
 | [usage-guard](skills/usage-guard/) | `/usage-guard [--queue] [--at <pct>] <task>` | Work a task continuously until 5h usage hits a threshold (default 99%), then stop and report — or with `--queue`, chain the remainder into the next block |
+
+### Session handoff
+
+Delegate scoped work to a fresh, visible Claude session in a new pane. **macOS + iTerm2-only**, and needs a one-time macOS Automation grant — see [handoff/README](skills/handoff/README.md).
+
+| Skill | Trigger | What it does |
+|-------|---------|-------------|
+| [handoff](skills/handoff/) | `/handoff <slug>` | Splits the current iTerm2 window, launches a fresh `claude` in the new pane, and relays a self-contained brief to it over cross-session messaging — a peer session you can watch and steer, unlike a background subagent |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Delegate scoped work to a fresh, visible Claude session in a new pane. **macOS +
 
 | Skill | Trigger | What it does |
 |-------|---------|-------------|
-| [handoff](skills/handoff/) | `/handoff <slug>` | Splits the current iTerm2 window, launches a fresh `claude` in the new pane, and relays a self-contained brief to it over cross-session messaging — a peer session you can watch and steer, unlike a background subagent |
+| [handoff](skills/handoff/) | `/handoff <slug>` | Splits the iTerm2 pane it was invoked from, launches a fresh `claude` in the new pane, and relays a self-contained brief to it over cross-session messaging — a peer session you can watch and steer, unlike a background subagent |
 
 ---
 

--- a/skills/handoff/README.md
+++ b/skills/handoff/README.md
@@ -1,0 +1,61 @@
+# handoff
+
+Delegate scoped work to a **fresh, visible Claude session in a new iTerm2 pane**.
+`/handoff` splits the current iTerm2 window (the cmd+d equivalent), launches a new
+`claude` in the pane, and relays a self-contained brief to it over
+[cross-session messaging](https://code.claude.com/docs/en/cross-session-messaging).
+The result is a peer session you can watch and take over — unlike a background
+subagent — without hand-typing the context into it.
+
+Reach for it when you want a sibling session working alongside you: run a long
+migration in one pane while you keep going, split off a focused sub-task, or fan
+a chore out to a pane you can steer.
+
+## Requirements
+
+- **macOS + iTerm2 only.** The launcher drives iTerm2's AppleScript API via
+  `osascript` and guards on `TERM_PROGRAM=iTerm.app`; it exits with a clear
+  message in any other terminal or OS.
+- **Claude Code ≥ 2.1.224** for cross-session messaging (the relay). The optional
+  "tell me when it's done" notice (`notify_when_idle`) needs **≥ 2.1.236**.
+- Cross-session messaging must not be disabled — no `SendMessage`/`ListAgents`
+  deny rules, and the feature-flag env vars (`DISABLE_TELEMETRY`, `DO_NOT_TRACK`,
+  etc.) left unset. See the docs' Availability section.
+
+## First-run setup: macOS Automation permission
+
+The first time the launcher tells iTerm2 to open a pane, macOS shows a one-time
+**Automation** prompt ("… wants to control iTerm"). Approve it. This is an
+out-of-band OS grant a plugin can't make for you — like the statusline tap the
+`queue` skill needs. If it was denied earlier, re-enable it under **System
+Settings → Privacy & Security → Automation**, then retry. Until it's granted the
+launcher reports it couldn't create the pane.
+
+## How it works
+
+1. `scripts/spawn-pane.sh <slug> [cwd]` computes a unique session name
+   (`<slug>-<suffix>`), splits the current iTerm2 session vertically, and types
+   `claude --name <name> --settings '{"crossSessionInbound":"accept"}'` into the
+   new pane. The `crossSessionInbound: accept` setting is what lets the relayed
+   brief arrive without a hold dialog.
+2. The script polls until the new `claude` process is up, so the caller confirms
+   registration with a `ListAgents` check or two — never a poll loop.
+3. Claude composes a self-contained brief and sends it in a single `SendMessage`
+   to the new session's name, optionally subscribing `notify_when_idle`.
+
+The new session launches in the caller's directory with interactive permissions
+by default; pass `--perm-mode acceptEdits` to the launcher for hands-off editing.
+
+## Configuration (env)
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `HANDOFF_REGISTER_TIMEOUT` | `20` | Seconds the launcher waits for the new `claude` process before reporting `LAUNCHED=timeout` |
+
+## Files
+
+- `SKILL.md` — model-facing instructions.
+- `scripts/spawn-pane.sh` — the iTerm2 launcher (guard, unique name, split, wait).
+
+Tests: `tests/handoff/caliper-test_spawn_pane.sh` (guards, name/arg validation,
+launch-line construction — via `--dry-run`, so it needs no iTerm2 and runs on CI).

--- a/skills/handoff/README.md
+++ b/skills/handoff/README.md
@@ -1,7 +1,7 @@
 # handoff
 
 Delegate scoped work to a **fresh, visible Claude session in a new iTerm2 pane**.
-`/handoff` splits the current iTerm2 window (the cmd+d equivalent), launches a new
+`/handoff` splits the iTerm2 pane it was invoked from (the cmd+d equivalent), launches a new
 `claude` in the pane, and relays a self-contained brief to it over
 [cross-session messaging](https://code.claude.com/docs/en/cross-session-messaging).
 The result is a peer session you can watch and take over — unlike a background
@@ -34,7 +34,9 @@ launcher reports it couldn't create the pane.
 ## How it works
 
 1. `scripts/spawn-pane.sh <slug> [cwd]` computes a unique session name
-   (`<slug>-<suffix>`), splits the current iTerm2 session vertically, and types
+   (`<slug>-<suffix>`), splits the invoking iTerm2 session vertically (found by
+   `$ITERM_SESSION_ID`, so the pane lands in handoff's own tab even if focus has
+   moved to another tab), and types
    `claude --name <name> --settings '{"crossSessionInbound":"accept"}'` into the
    new pane. The `crossSessionInbound: accept` setting is what lets the relayed
    brief arrive without a hold dialog.

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -5,7 +5,7 @@ description: Use when the user wants to hand scoped work to a fresh, visible Cla
 
 # /handoff — delegate scoped work to a sibling session in a new iTerm2 pane
 
-Split the current iTerm2 window, launch a fresh `claude` in the new pane, and
+Split the iTerm2 pane you ran it from, launch a fresh `claude` in the new pane, and
 relay a self-contained brief to it over cross-session messaging — so the user
 gets a visible, steerable peer session doing the work, without hand-typing the
 context into it.

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: handoff
+description: Use when the user wants to hand scoped work to a fresh, visible Claude session in a new iTerm2 pane — "/handoff", "hand this off to another session", "spin up a pane and have it do X", "open a new claude in a split and tell it to…", "delegate this to a sidecar session", "kick off a parallel session for this".
+---
+
+# /handoff — delegate scoped work to a sibling session in a new iTerm2 pane
+
+Split the current iTerm2 window, launch a fresh `claude` in the new pane, and
+relay a self-contained brief to it over cross-session messaging — so the user
+gets a visible, steerable peer session doing the work, without hand-typing the
+context into it.
+
+Use this instead of a background subagent when the point is a pane the user can
+watch and take over. macOS + iTerm2 only.
+
+## Before spawning
+
+1. **Scope the work.** Nail down what the sibling session should do: the task,
+   its boundaries, and how it knows it's done. If the request is vague, ask — the
+   brief is the only thing that travels (see below), so gaps can't be filled in later.
+2. **Permission-laundering check.** Never relay work that *this* session was
+   denied or that its own permission settings would block. A peer doing it for
+   you bypasses the user's decision. Route blocked work back to the user instead.
+
+## Spawn the pane
+
+Run the launcher (executable — invoke directly, don't prefix with `bash`):
+
+```text
+./skills/handoff/scripts/spawn-pane.sh <slug> [cwd]
+```
+
+- `<slug>` — short kebab-case label for the work (e.g. `run-migration`). The
+  script appends a random suffix to form the session's `--name`, so it reads back
+  a unique `NAME=` the caller addresses. The suffix matters: if two sessions
+  shared a name, Claude Code would silently rename one to a variant and the
+  address you hold would be wrong.
+- `[cwd]` — defaults to the current directory. Same checkout as the caller; the
+  sibling uses its own skills to enter a worktree if it will edit files.
+- `--perm-mode acceptEdits` — optional, only if the user wants the pane editing
+  hands-off. Default is interactive: the pane is right there to answer prompts.
+
+The launcher opens the split, types the launch line into it, and waits for the
+new `claude` process to come up. Read `NAME=` from its output. If it prints
+`LAUNCHED=timeout` or errors, relay the message and stop — don't message a
+session that isn't up. (First run also triggers a one-time macOS Automation
+permission prompt — see README.)
+
+The launch line sets `--settings '{"crossSessionInbound":"accept"}'`. That flag
+is load-bearing: without it the brief you send could sit in a hold dialog in the
+new pane instead of reaching the sibling Claude.
+
+## Relay the brief
+
+Confirm the session registered: call `ListAgents` and look for `NAME`. It should
+be there (the launcher already waited for the process); if not, wait a beat and
+check once more — at most two or three times, never a poll loop.
+
+Then send **one** `SendMessage` to `NAME`. Write a **self-contained** brief —
+only plain text crosses, never this conversation's history or files, so include
+everything the sibling needs:
+
+- **Context** — what this is and why, enough to act without your transcript.
+- **Scope** — exactly what to do, and what's out of scope.
+- **Constraints** — repo conventions, files to touch/avoid, tests to run.
+- **Done-criteria** — how it knows it's finished.
+- **Reply when done** — ask it to message back the session that sent this brief
+  (it has your address from the message's sender).
+
+Batch all of that into that single message. Rapid bursts to one inbox get
+refused at the sender, so don't dribble the brief across several sends.
+
+## Optionally hear back
+
+If the user wants to be told when the sibling finishes, add
+`notify_when_idle: true` to the `SendMessage` (or send a bare subscription).
+That's the mechanism for "tell me when it's done" — **never** poll `ListAgents`
+in a loop or send "are you done?" messages to check on it.
+
+## Report
+
+Tell the user the pane is open, the session's name, and that they can steer it
+directly in that pane or ask you to relay follow-ups to it.
+
+## Notes
+
+- **macOS + iTerm2 only.** The launcher guards on `TERM_PROGRAM=iTerm.app` and
+  exits with a clear message elsewhere.
+- Same-machine, peer-to-peer. Cross-machine/cloud relay is out of scope.
+- The sibling is independent: its own permission prompts apply to anything the
+  brief asks for, and a message from you never counts as the user's approval there.

--- a/skills/handoff/scripts/spawn-pane.sh
+++ b/skills/handoff/scripts/spawn-pane.sh
@@ -12,10 +12,10 @@
 # Usage:
 #   spawn-pane.sh [--dry-run] [--perm-mode <mode>] <slug> [cwd]
 #
-#   <slug>        Short kebab-case label for the work (e.g. "run-tests"). A short
-#                 random suffix is appended to form the session --name, so two
-#                 handoffs never collide and get auto-renamed by Claude Code
-#                 (a rename would break the caller's known address).
+#   <slug>        Short kebab-case label for the work (e.g. "run-tests"). A random
+#                 suffix is appended to form the session --name, so concurrent
+#                 handoffs are very unlikely to collide and get auto-renamed by
+#                 Claude Code (a rename would break the caller's known address).
 #   [cwd]         Working directory for the new session (default: $PWD — the
 #                 same directory the caller is in).
 #   --perm-mode   Passed through as `claude --permission-mode <mode>` (e.g.
@@ -59,6 +59,15 @@ case "$slug" in
 esac
 [ -n "$cwd" ] || cwd="$PWD"
 [ -d "$cwd" ] || { echo "ERROR: cwd '$cwd' is not a directory." >&2; exit 4 ;}
+# perm_mode also lands on the launch line typed into the pane, so it needs the same
+# shell-safety guard as slug. Permission-mode names are letters only (default,
+# acceptEdits, plan, bypassPermissions, …); rejecting anything else keeps a stray
+# value from smuggling shell metacharacters onto that line.
+if [ -n "$perm_mode" ]; then
+  case "$perm_mode" in
+    *[!a-zA-Z]*) echo "ERROR: --perm-mode '$perm_mode' is not a valid permission mode (letters only, e.g. acceptEdits)." >&2; exit 4 ;;
+  esac
+fi
 
 # Guard: this only works from iTerm2. Read $TERM_PROGRAM (Claude Code exports the
 # host terminal into it) rather than probing the app, so the failure is a clear
@@ -68,9 +77,11 @@ if [ "${TERM_PROGRAM:-}" != "iTerm.app" ]; then
   exit 2
 fi
 
-# Deterministic-but-unique name: slug + short hex suffix from $RANDOM. The caller
-# reads NAME= back and addresses the new session by it.
-suffix="$(printf '%03x' "$(( RANDOM % 4096 ))")"
+# Name = slug + a random hex suffix so concurrent handoffs are very unlikely to
+# share a name (a collision would trigger Claude Code's auto-rename, which breaks
+# the address the caller holds). The caller reads NAME= back and addresses the new
+# session by it. Probabilistic, not guaranteed — but 16 bits is ample here.
+suffix="$(printf '%04x' "$RANDOM")"
 name="${slug}-${suffix}"
 
 # The pane must be split off the session that INVOKED handoff — not whatever
@@ -142,11 +153,13 @@ then
 fi
 
 # Wait for the worker process to come up so the caller can message it right away.
-# Match the full `claude --name <name>` on the command line; the [c] bracket trick
-# keeps this grep from matching itself in the ps listing.
+# Match the unique `--name <name> --settings` signature — not a leading `claude`
+# token, since some install shapes exec the CLI as e.g. `node .../cli.js`. The [-]
+# bracket trick makes the pattern (a literal `--name …`) not match this grep's own
+# entry in the ps listing. By now osascript has exited, so nothing else carries it.
 waited=0
 while [ "$waited" -lt "$REGISTER_TIMEOUT" ]; do
-  if ps -Ao command= | grep -q "[c]laude --name ${name}"; then
+  if ps -Ao command= | grep -q "[-]-name ${name} --settings"; then
     echo "LAUNCHED=yes"
     exit 0
   fi

--- a/skills/handoff/scripts/spawn-pane.sh
+++ b/skills/handoff/scripts/spawn-pane.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# spawn-pane.sh — open a new iTerm2 split pane and launch a fresh `claude`
+# session in it, ready to receive a relayed brief over cross-session messaging.
+# macOS + iTerm2 only (uses osascript against iTerm's AppleScript API).
+#
+# The new session launches with `--settings '{"crossSessionInbound":"accept"}'`
+# so the caller's relayed brief is DELIVERED, not held for approval — without it
+# the whole point of the skill breaks (a bypass-vs-prompt class mismatch would
+# leave the brief sitting in a hold dialog in the new pane). See the skill's
+# SKILL.md and the cross-session-messaging docs.
+#
+# Usage:
+#   spawn-pane.sh [--dry-run] [--perm-mode <mode>] <slug> [cwd]
+#
+#   <slug>        Short kebab-case label for the work (e.g. "run-tests"). A short
+#                 random suffix is appended to form the session --name, so two
+#                 handoffs never collide and get auto-renamed by Claude Code
+#                 (a rename would break the caller's known address).
+#   [cwd]         Working directory for the new session (default: $PWD — the
+#                 same directory the caller is in).
+#   --perm-mode   Passed through as `claude --permission-mode <mode>` (e.g.
+#                 acceptEdits). Omitted by default: interactive, so the visible
+#                 pane prompts for permissions like any hands-on session.
+#   --dry-run     Print what would be launched (NAME=, CWD=, LAUNCH_CMD=) and
+#                 exit without touching iTerm2 or polling. Used by tests and to
+#                 preview the launch line.
+#
+# Prints KEY=VALUE lines on success. On real (non-dry-run) success it also polls
+# until the new claude process is up (so the caller needs at most a couple of
+# ListAgents checks, never a poll loop) and prints LAUNCHED=yes, or LAUNCHED=timeout
+# with a non-zero exit if the process never appeared.
+set -u
+
+REGISTER_TIMEOUT="${HANDOFF_REGISTER_TIMEOUT:-20}"  # seconds to wait for the process
+SETTINGS_JSON='{"crossSessionInbound":"accept"}'
+
+dry_run="no"
+perm_mode=""
+slug=""
+cwd=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)   dry_run="yes"; shift ;;
+    --perm-mode) [ $# -ge 2 ] || { echo "ERROR: --perm-mode requires a value." >&2; exit 4; }
+                 perm_mode="$2"; shift 2 ;;
+    --perm-mode=*) perm_mode="${1#*=}"; shift ;;
+    -*)          echo "ERROR: unknown option '$1' (usage: spawn-pane.sh [--dry-run] [--perm-mode <mode>] <slug> [cwd])." >&2; exit 4 ;;
+    *)           if [ -z "$slug" ]; then slug="$1"; elif [ -z "$cwd" ]; then cwd="$1";
+                 else echo "ERROR: too many arguments." >&2; exit 4; fi
+                 shift ;;
+  esac
+done
+
+[ -n "$slug" ] || { echo "ERROR: a <slug> is required (usage: spawn-pane.sh [--dry-run] [--perm-mode <mode>] <slug> [cwd])." >&2; exit 4; }
+# Slug must be safe to drop straight onto a shell command line as `--name <slug>`.
+case "$slug" in
+  *[!a-zA-Z0-9._-]*) echo "ERROR: slug '$slug' has unsafe characters — use letters, digits, dot, underscore, dash." >&2; exit 4 ;;
+esac
+[ -n "$cwd" ] || cwd="$PWD"
+[ -d "$cwd" ] || { echo "ERROR: cwd '$cwd' is not a directory." >&2; exit 4 ;}
+
+# Guard: this only works from iTerm2. Read $TERM_PROGRAM (Claude Code exports the
+# host terminal into it) rather than probing the app, so the failure is a clear
+# message instead of an AppleScript error. Tests set TERM_PROGRAM to exercise both.
+if [ "${TERM_PROGRAM:-}" != "iTerm.app" ]; then
+  echo "ERROR: handoff needs iTerm2 (TERM_PROGRAM='${TERM_PROGRAM:-unset}', expected 'iTerm.app'). This skill is macOS + iTerm2 only." >&2
+  exit 2
+fi
+
+# Deterministic-but-unique name: slug + short hex suffix from $RANDOM. The caller
+# reads NAME= back and addresses the new session by it.
+suffix="$(printf '%03x' "$(( RANDOM % 4096 ))")"
+name="${slug}-${suffix}"
+
+# Build the launch command as ONE shell line to type into the new pane. cwd is
+# %q-quoted so spaces survive; SETTINGS_JSON stays single-quoted so the pane's
+# shell hands it to claude intact. This whole string is passed to AppleScript as
+# an argv element (never interpolated into the AppleScript source), so `write text`
+# sends it verbatim — the three quoting layers (bash -> AppleScript -> shell)
+# never collide.
+q_cwd="$(printf '%q' "$cwd")"
+launch_cmd="cd ${q_cwd} && claude --name ${name} --settings '${SETTINGS_JSON}'"
+[ -n "$perm_mode" ] && launch_cmd="${launch_cmd} --permission-mode ${perm_mode}"
+
+echo "NAME=${name}"
+echo "CWD=${cwd}"
+echo "LAUNCH_CMD=${launch_cmd}"
+
+if [ "$dry_run" = "yes" ]; then
+  echo "LAUNCHED=dry-run"
+  exit 0
+fi
+
+# Split the current iTerm2 session vertically (the cmd+d equivalent) and type the
+# launch line into the new pane. The AppleScript is a QUOTED heredoc — nothing
+# from bash is interpolated into it; the command arrives via `on run argv`.
+if ! osascript - "$launch_cmd" <<'APPLESCRIPT'
+on run argv
+  set theCmd to item 1 of argv
+  tell application "iTerm"
+    if (count of windows) is 0 then error "no iTerm2 window is open" number 2
+    tell current session of current window
+      set newSession to (split vertically with same profile)
+    end tell
+    tell newSession
+      write text theCmd
+    end tell
+  end tell
+end run
+APPLESCRIPT
+then
+  echo "ERROR: could not create the iTerm2 pane (is a window open, and has iTerm2 been granted Automation access? see README)." >&2
+  echo "LAUNCHED=failed"
+  exit 3
+fi
+
+# Wait for the worker process to come up so the caller can message it right away.
+# Match the full `claude --name <name>` on the command line; the [c] bracket trick
+# keeps this grep from matching itself in the ps listing.
+waited=0
+while [ "$waited" -lt "$REGISTER_TIMEOUT" ]; do
+  if ps -Ao command= | grep -q "[c]laude --name ${name}"; then
+    echo "LAUNCHED=yes"
+    exit 0
+  fi
+  sleep 1
+  waited=$(( waited + 1 ))
+done
+
+echo "WARNING: the new session's claude process didn't appear within ${REGISTER_TIMEOUT}s — the pane may still be starting. Check the pane, then confirm with ListAgents before messaging." >&2
+echo "LAUNCHED=timeout"
+exit 5

--- a/skills/handoff/scripts/spawn-pane.sh
+++ b/skills/handoff/scripts/spawn-pane.sh
@@ -73,6 +73,14 @@ fi
 suffix="$(printf '%03x' "$(( RANDOM % 4096 ))")"
 name="${slug}-${suffix}"
 
+# The pane must be split off the session that INVOKED handoff — not whatever
+# session happens to be focused when osascript runs (that lands the pane in the
+# wrong tab if the user has since switched away). iTerm2 exports the invoking
+# session's UUID as $ITERM_SESSION_ID ("w0t0p0:<UUID>"); the part after the colon
+# matches an AppleScript session's `id`. Empty (older iTerm2) falls back to the
+# current session in the AppleScript below.
+invoker_id="${ITERM_SESSION_ID##*:}"
+
 # Build the launch command as ONE shell line to type into the new pane. cwd is
 # %q-quoted so spaces survive; SETTINGS_JSON stays single-quoted so the pane's
 # shell hands it to claude intact. This whole string is passed to AppleScript as
@@ -85,6 +93,7 @@ launch_cmd="cd ${q_cwd} && claude --name ${name} --settings '${SETTINGS_JSON}'"
 
 echo "NAME=${name}"
 echo "CWD=${cwd}"
+echo "INVOKER_SESSION=${invoker_id}"
 echo "LAUNCH_CMD=${launch_cmd}"
 
 if [ "$dry_run" = "yes" ]; then
@@ -92,15 +101,32 @@ if [ "$dry_run" = "yes" ]; then
   exit 0
 fi
 
-# Split the current iTerm2 session vertically (the cmd+d equivalent) and type the
+# Split the INVOKING iTerm2 session vertically (the cmd+d equivalent) and type the
 # launch line into the new pane. The AppleScript is a QUOTED heredoc — nothing
-# from bash is interpolated into it; the command arrives via `on run argv`.
-if ! osascript - "$launch_cmd" <<'APPLESCRIPT'
+# from bash is interpolated into it; both the command and the invoker's session id
+# arrive via `on run argv`. It finds the session whose id matches (so the pane
+# lands in handoff's own tab, not the focused one); an empty id falls back to the
+# current session.
+if ! osascript - "$launch_cmd" "$invoker_id" <<'APPLESCRIPT'
 on run argv
   set theCmd to item 1 of argv
+  set wantId to item 2 of argv
   tell application "iTerm"
     if (count of windows) is 0 then error "no iTerm2 window is open" number 2
-    tell current session of current window
+    if wantId is "" then
+      set target to current session of current window
+    else
+      set target to missing value
+      repeat with w in windows
+        repeat with t in tabs of w
+          repeat with s in sessions of t
+            if (id of s) is wantId then set target to s
+          end repeat
+        end repeat
+      end repeat
+      if target is missing value then error "handoff's own iTerm2 session (" & wantId & ") was not found" number 4
+    end if
+    tell target
       set newSession to (split vertically with same profile)
     end tell
     tell newSession

--- a/tests/handoff/caliper-test_spawn_pane.sh
+++ b/tests/handoff/caliper-test_spawn_pane.sh
@@ -7,6 +7,11 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 HELPER="$REPO_ROOT/skills/handoff/scripts/spawn-pane.sh"
 
+# Scrub the runner's own iTerm2 session id so cases that don't set it inline see an
+# empty value (not whatever tab this test happens to run in). Inline
+# `ITERM_SESSION_ID=… run …` still overrides per case.
+unset ITERM_SESSION_ID
+
 pass=0; fail=0
 
 # Run HELPER; capture out/err/rc. First arg is the TERM_PROGRAM to simulate.
@@ -32,7 +37,7 @@ field() { echo "$STDOUT" | sed -n "s/^$1=//p"; }
 # --- dry-run happy path ---
 run "iTerm.app" --dry-run run-tests /tmp
 assert "dry-run exits 0"                    '[[ $RC -eq 0 ]]'
-assert "NAME is slug + suffix"              '[[ "$(field NAME)" =~ ^run-tests-[0-9a-f]{3}$ ]]'
+assert "NAME is slug + suffix"              '[[ "$(field NAME)" =~ ^run-tests-[0-9a-f]{4}$ ]]'
 assert "CWD echoes the passed dir"          '[[ "$(field CWD)" == "/tmp" ]]'
 assert "LAUNCH_CMD cds to cwd"              '[[ "$(field LAUNCH_CMD)" == cd\ /tmp\ * ]]'
 assert "LAUNCH_CMD names the session"       '[[ "$(field LAUNCH_CMD)" == *"claude --name run-tests-"* ]]'
@@ -56,9 +61,19 @@ assert "empty ITERM_SESSION_ID -> empty INVOKER_SESSION (AppleScript falls back)
 run "iTerm.app" --dry-run just-a-slug
 assert "cwd defaults to invocation dir"     '[[ -n "$(field CWD)" && -d "$(field CWD)" ]]'
 
-# --- --perm-mode passthrough ---
+# --- --perm-mode passthrough & validation ---
 run "iTerm.app" --dry-run --perm-mode acceptEdits edits /tmp
 assert "--perm-mode appends --permission-mode" '[[ "$(field LAUNCH_CMD)" == *"--permission-mode acceptEdits"* ]]'
+
+run "iTerm.app" --dry-run --perm-mode=plan edits /tmp
+assert "--perm-mode=X form also appends" '[[ "$(field LAUNCH_CMD)" == *"--permission-mode plan"* ]]'
+
+run "iTerm.app" --dry-run --perm-mode
+assert "--perm-mode with no value exits 4" '[[ $RC -eq 4 ]]'
+
+run "iTerm.app" --dry-run --perm-mode 'acceptEdits; rm -rf ~' edits /tmp
+assert "shell-metachar perm-mode rejected (exit 4)" '[[ $RC -eq 4 ]]'
+assert "rejected perm-mode never reaches LAUNCH_CMD"  '[[ "$STDOUT" != *"rm -rf"* ]]'
 
 # --- iTerm2 guard ---
 run "Apple_Terminal" --dry-run run-tests /tmp
@@ -83,6 +98,9 @@ assert "nonexistent cwd exits 4"            '[[ $RC -eq 4 ]]'
 
 run "iTerm.app" --dry-run --bogus good-slug /tmp
 assert "unknown option exits 4"             '[[ $RC -eq 4 ]]'
+
+run "iTerm.app" --dry-run one two three
+assert "too many arguments exits 4"         '[[ $RC -eq 4 ]]'
 
 # --- cwd with spaces survives quoting ---
 sp="$(mktemp -d "${TMPDIR:-/tmp}/handoff test XXXXXX")"; trap 'rm -rf "$sp"' EXIT

--- a/tests/handoff/caliper-test_spawn_pane.sh
+++ b/tests/handoff/caliper-test_spawn_pane.sh
@@ -15,7 +15,7 @@ run() {
   local tmp_out tmp_err
   tmp_out="$(mktemp)"; tmp_err="$(mktemp)"
   set +e
-  env TERM_PROGRAM="$term" PATH="$PATH" HOME="$HOME" bash "$HELPER" "$@" \
+  env TERM_PROGRAM="$term" ITERM_SESSION_ID="${ITERM_SESSION_ID:-}" PATH="$PATH" HOME="$HOME" bash "$HELPER" "$@" \
     >"$tmp_out" 2>"$tmp_err"
   RC=$?
   set -e
@@ -41,6 +41,16 @@ assert "LAUNCH_CMD sets crossSessionInbound accept" \
   $'[[ "$(field LAUNCH_CMD)" == *"--settings \'{\\"crossSessionInbound\\":\\"accept\\"}\'"* ]]'
 assert "dry-run reports LAUNCHED=dry-run"   '[[ "$(field LAUNCHED)" == "dry-run" ]]'
 assert "no --permission-mode by default"    '[[ "$(field LAUNCH_CMD)" != *"--permission-mode"* ]]'
+
+# --- invoker session id: split targets handoff's own pane, not the focused one ---
+ITERM_SESSION_ID="w0t2p1:ABC-123-DEF" run "iTerm.app" --dry-run tabbed /tmp
+assert "INVOKER_SESSION strips the wNtNpN prefix" '[[ "$(field INVOKER_SESSION)" == "ABC-123-DEF" ]]'
+
+ITERM_SESSION_ID="BARE-UUID-NO-COLON" run "iTerm.app" --dry-run tabbed /tmp
+assert "INVOKER_SESSION passes a colon-less id through" '[[ "$(field INVOKER_SESSION)" == "BARE-UUID-NO-COLON" ]]'
+
+ITERM_SESSION_ID="" run "iTerm.app" --dry-run tabbed /tmp
+assert "empty ITERM_SESSION_ID -> empty INVOKER_SESSION (AppleScript falls back)" '[[ -z "$(field INVOKER_SESSION)" ]]'
 
 # --- default cwd is $PWD ---
 run "iTerm.app" --dry-run just-a-slug

--- a/tests/handoff/caliper-test_spawn_pane.sh
+++ b/tests/handoff/caliper-test_spawn_pane.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Tests for skills/handoff/scripts/spawn-pane.sh
+# Uses --dry-run so no iTerm2 is touched; TERM_PROGRAM is set per case to
+# exercise the guard. Portable (no BSD-date dependency) — runs on Linux CI too.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HELPER="$REPO_ROOT/skills/handoff/scripts/spawn-pane.sh"
+
+pass=0; fail=0
+
+# Run HELPER; capture out/err/rc. First arg is the TERM_PROGRAM to simulate.
+run() {
+  local term="$1"; shift
+  local tmp_out tmp_err
+  tmp_out="$(mktemp)"; tmp_err="$(mktemp)"
+  set +e
+  env TERM_PROGRAM="$term" PATH="$PATH" HOME="$HOME" bash "$HELPER" "$@" \
+    >"$tmp_out" 2>"$tmp_err"
+  RC=$?
+  set -e
+  STDOUT="$(cat "$tmp_out")"; STDERR="$(cat "$tmp_err")"
+  rm -f "$tmp_out" "$tmp_err"
+}
+assert() {
+  local desc="$1" cond="$2"
+  if eval "$cond"; then echo "PASS: $desc"; pass=$((pass+1))
+  else echo "FAIL: $desc"; echo "  STDOUT: $STDOUT"; echo "  STDERR: $STDERR"; echo "  RC: $RC"; fail=$((fail+1)); fi
+}
+field() { echo "$STDOUT" | sed -n "s/^$1=//p"; }
+
+# --- dry-run happy path ---
+run "iTerm.app" --dry-run run-tests /tmp
+assert "dry-run exits 0"                    '[[ $RC -eq 0 ]]'
+assert "NAME is slug + suffix"              '[[ "$(field NAME)" =~ ^run-tests-[0-9a-f]{3}$ ]]'
+assert "CWD echoes the passed dir"          '[[ "$(field CWD)" == "/tmp" ]]'
+assert "LAUNCH_CMD cds to cwd"              '[[ "$(field LAUNCH_CMD)" == cd\ /tmp\ * ]]'
+assert "LAUNCH_CMD names the session"       '[[ "$(field LAUNCH_CMD)" == *"claude --name run-tests-"* ]]'
+# The accept setting is load-bearing: without it the relayed brief would be held.
+assert "LAUNCH_CMD sets crossSessionInbound accept" \
+  $'[[ "$(field LAUNCH_CMD)" == *"--settings \'{\\"crossSessionInbound\\":\\"accept\\"}\'"* ]]'
+assert "dry-run reports LAUNCHED=dry-run"   '[[ "$(field LAUNCHED)" == "dry-run" ]]'
+assert "no --permission-mode by default"    '[[ "$(field LAUNCH_CMD)" != *"--permission-mode"* ]]'
+
+# --- default cwd is $PWD ---
+run "iTerm.app" --dry-run just-a-slug
+assert "cwd defaults to invocation dir"     '[[ -n "$(field CWD)" && -d "$(field CWD)" ]]'
+
+# --- --perm-mode passthrough ---
+run "iTerm.app" --dry-run --perm-mode acceptEdits edits /tmp
+assert "--perm-mode appends --permission-mode" '[[ "$(field LAUNCH_CMD)" == *"--permission-mode acceptEdits"* ]]'
+
+# --- iTerm2 guard ---
+run "Apple_Terminal" --dry-run run-tests /tmp
+assert "non-iTerm exits 2"                  '[[ $RC -eq 2 ]]'
+assert "non-iTerm explains the requirement" '[[ "$STDERR" == *"iTerm2"* ]]'
+
+run "" --dry-run run-tests /tmp
+assert "unset TERM_PROGRAM exits 2"         '[[ $RC -eq 2 ]]'
+
+# --- argument validation ---
+run "iTerm.app" --dry-run
+assert "missing slug exits 4"               '[[ $RC -eq 4 ]]'
+
+run "iTerm.app" --dry-run "bad slug"
+assert "unsafe slug exits 4"                '[[ $RC -eq 4 ]]'
+
+run "iTerm.app" --dry-run 'evil;rm'
+assert "shell-metachar slug exits 4"        '[[ $RC -eq 4 ]]'
+
+run "iTerm.app" --dry-run good-slug /no/such/dir
+assert "nonexistent cwd exits 4"            '[[ $RC -eq 4 ]]'
+
+run "iTerm.app" --dry-run --bogus good-slug /tmp
+assert "unknown option exits 4"             '[[ $RC -eq 4 ]]'
+
+# --- cwd with spaces survives quoting ---
+sp="$(mktemp -d "${TMPDIR:-/tmp}/handoff test XXXXXX")"; trap 'rm -rf "$sp"' EXIT
+run "iTerm.app" --dry-run spaced "$sp"
+assert "spaced cwd exits 0"                 '[[ $RC -eq 0 ]]'
+assert "spaced cwd is escaped in LAUNCH_CMD" '[[ "$(field LAUNCH_CMD)" == *"handoff\\ test"* ]]'
+
+echo "----"
+echo "PASS=$pass FAIL=$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary
- New macOS + iTerm2-only skill **`handoff`**. `/handoff <slug>` splits the current iTerm2 window (the cmd+d equivalent), launches a fresh `claude` in the new pane with a unique `--name` and `--settings '{"crossSessionInbound":"accept"}'`, waits for it to register, then relays a self-contained brief to it over [cross-session messaging](https://code.claude.com/docs/en/cross-session-messaging) (`SendMessage`), optionally subscribing `notify_when_idle`.
- The point: a **visible, steerable peer session** in a pane you can watch and take over — unlike a background subagent — without hand-typing context into it.
- `scripts/spawn-pane.sh` drives iTerm2 via `osascript` using a quoted heredoc + `on run argv` so nothing interpolates across the bash → AppleScript → shell quoting layers; guards on `TERM_PROGRAM=iTerm.app`; generates a unique name (slug + suffix) to dodge Claude Code's rename-on-collision; polls for the new process so the caller needs no `ListAgents` poll loop. `--dry-run` and `--perm-mode` flags included.
- Registered in the `claude-caliper` (→2.1.0) and `claude-caliper-tooling` (→1.53.0) bundles; root README + skill tables updated.

## Test plan
- `tests/handoff/caliper-test_spawn_pane.sh` — 20 dry-run cases (iTerm2 guard, arg/slug validation, launch-line construction incl. the load-bearing `crossSessionInbound:accept` flag and space-quoted cwd). CI-safe (no iTerm2), wired into `.github/workflows/test.yml`.
- **Live end-to-end** in the target env (iTerm2, Claude Code 2.1.245): real spawn → `LAUNCHED=yes` → session addressable via `ListAgents` → `SendMessage` delivered (not held) → `HANDOFF-E2E-OK` reply received → `notify_when_idle` notice fired.
- iTerm2 AppleScript vocabulary (`split vertically with same profile`, `write text`) confirmed live; marketplace JSON valid; hook-test baseline clean.
- Implementation-review passed (one medium README-drift finding, fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `/handoff <slug>` workflow for launching a fresh Claude session in a visible macOS/iTerm2 pane.
  * Supports sending a self-contained brief between sessions, optional completion notifications, dry runs, and configurable permission modes.
  * Added validation and clear reporting for launch failures, unsupported environments, and timeouts.

* **Documentation**
  * Updated package documentation and requirements for the new session handoff skill.

* **Tests**
  * Added automated coverage for launch commands, argument validation, working directories, quoting, and environment checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->